### PR TITLE
DAC-847 Connect lambda to firehose

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -150,7 +150,7 @@ Resources:
             - - !Ref Environment
               - !Ref DeliveryStreamName
         BufferingHints:
-          IntervalInSeconds: 900
+          IntervalInSeconds: 60
           SizeInMBs: 128
         RoleARN: !GetAtt IAMRoleKinesisFirehose.Arn
         Prefix: '!{partitionKeyFromQuery:datasource}/!{partitionKeyFromQuery:event_name}/year=!{partitionKeyFromQuery:year}/month=!{partitionKeyFromQuery:month}/day=!{partitionKeyFromQuery:day}/'
@@ -165,7 +165,7 @@ Resources:
             - Type: MetadataExtraction
               Parameters:
                 - ParameterName: MetadataExtractionQuery
-                  ParameterValue: '{datasource: ''txma'',event_name: .event_name,year:now | strftime("%Y"),month:now | strftime("%m"),day:now | strftime("%d")}'
+                  ParameterValue: '{datasource: "txma",event_name: .event_name,year:now | strftime("%Y"),month:now | strftime("%m"),day:now | strftime("%d")}'
                 - ParameterName: JsonParsingEngine
                   ParameterValue: 'JQ-1.6'
         DataFormatConversionConfiguration:


### PR DESCRIPTION
DAC-847 Connect lambda to firehose

- Add delivery stream name to lambda environment variable
- Add needed firehose permission to lambda policy
- Give raw layer bucket better name and remove some checkov skips
- Add global log bucket inspired by BTM

Firehose changes from @sbeesla-gds

- Fix quoting error in MetadataExtractionQuery
- Decrease buffering interval to one minute
