### PR TITLE
Enforce up-to-date branches for deployments

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -16,8 +16,18 @@ jobs:
       - name: Validate input environment
         run: scripts/validate-environment.sh -d ${{ inputs.environment }}
 
+  validate-branch-ahead:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0    # check out full history
+      - name: Validate ahead of main
+        run: scripts/validate-branch-ahead.sh
+
   deploy-to-aws:
-    needs: [ validate-environment ]
+    needs: [ validate-environment, validate-branch-ahead ]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
     permissions:
       id-token: write

--- a/scripts/validate-branch-ahead.sh
+++ b/scripts/validate-branch-ahead.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+# see https://stackoverflow.com/a/76151412 for inspiration for this script and the workflow code that calls it
+
+HEAD_HASH=$(git rev-parse --short HEAD)
+
+if ! git merge-base --is-ancestor origin/main "$HEAD_HASH"; then
+  exit 1
+fi


### PR DESCRIPTION
- Add validate-branch-ahead.sh script
- Add validate-branch-ahead job to deploy-to-aws workflow