### PR TITLE
DAC-1095 Enable CKV_AWS_99 Checkov rule

### DIFF
--- a/docs/development-decisions.md
+++ b/docs/development-decisions.md
@@ -70,3 +70,7 @@ Commit signing, branch protection and mandatory pull requests are taken from the
 Some configuration properties needed for deployment are stored in the AWS System Manager Parameter Store.
 This enables them to be [dynamically referenced](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-ssm) in the template.
 This approach is used by both BTM and TxMA.
+
+## Checkov skips
+
+An explanation of the Checkov checks we skip can be found [here](https://govukverify.atlassian.net/wiki/spaces/DAP/pages/3535503483/Checkov+Rules).

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -2,7 +2,5 @@
 
 * Implement precommit hooks. BTM and TxMA seem to use [Husky](https://typicode.github.io/husky)
 * Simplify the [Test and validate iac and lambdas](../.github/workflows/test-and-validate.yml) workflow
-    * Can we use an `npm` script for the checkov step, as they are used for other steps?
     * Can we extract the duplicated config of both jobs setting up node?
     * Run prettier once covering all js/ts/json/yaml - instead of separately for IaC and Lambdas?
-* Can we speed up the IaC checks?

--- a/iac/resources/global.yml
+++ b/iac/resources/global.yml
@@ -14,17 +14,19 @@ GlobalLogBucket:
       Status: Enabled
 
 GlueSecurityConfig:
-  # checkov:skip=CKV_AWS_99: Ensure Glue Security Configuration Encryption is enabled
   Type: AWS::Glue::SecurityConfiguration
   Properties:
-    Name: !Sub ${Environment}-dap-glue-security-config
+    Name: !Sub ${Environment}-dap-glue-security-configuration
     EncryptionConfiguration:
       CloudWatchEncryption:
-        CloudWatchEncryptionMode: DISABLED
+        CloudWatchEncryptionMode: SSE-KMS
+        KmsKeyArn: !GetAtt KmsKey.Arn
       JobBookmarksEncryption:
-        JobBookmarksEncryptionMode: DISABLED
+        JobBookmarksEncryptionMode: CSE-KMS
+        KmsKeyArn: !GetAtt KmsKey.Arn
       S3Encryptions:
-        - S3EncryptionMode: DISABLED
+        - S3EncryptionMode: SSE-KMS
+          KmsKeyArn: !GetAtt KmsKey.Arn
 
 TestSupportLambda:
   # checkov:skip=CKV_AWS_116: DLQ not needed for lambda driven by SQS
@@ -83,10 +85,18 @@ KmsKey:
               - sns.amazonaws.com
               - sqs.amazonaws.com
               - logs.amazonaws.com
+              - logs.eu-west-2.amazonaws.com
+              - glue.amazonaws.com
+            AWS:
+              - !GetAtt RawGlueCrawlerRole.Arn
+              - !GetAtt StageGlueCrawlerRole.Arn
+              - !GetAtt StepFunctionRole.Arn
           Action:
-            - kms:Encrypt
-            - kms:Decrypt
+            - kms:Encrypt*
+            - kms:Decrypt*
+            - kms:ReEncrypt*
             - kms:GenerateDataKey*
+            - kms:Describe*
           Resource: '*'
 
 KmsKeyAlias:

--- a/iac/resources/raw.yml
+++ b/iac/resources/raw.yml
@@ -274,6 +274,9 @@ RawGlueCrawlerRole:
               Resource:
                 - !Sub 'arn:aws:s3:::${RawLayerBucket}'
                 - !Sub 'arn:aws:s3:::${RawLayerBucket}/*'
+            - Effect: Allow
+              Action: 'logs:AssociateKmsKey'
+              Resource: 'arn:aws:logs:*:*:/aws-glue/*'
 
 RawGlueDatabase:
   Type: AWS::Glue::Database

--- a/iac/resources/stage.yml
+++ b/iac/resources/stage.yml
@@ -478,3 +478,6 @@ StageGlueCrawlerRole:
               Resource:
                 - !Sub 'arn:aws:s3:::${StageLayerBucket}'
                 - !Sub 'arn:aws:s3:::${StageLayerBucket}/*'
+            - Effect: Allow
+              Action: 'logs:AssociateKmsKey'
+              Resource: 'arn:aws:logs:*:*:/aws-glue/*'


### PR DESCRIPTION
- Enable encryption in existing glue security config using existing KMS key
- Add permissions to KMS key and state machine and crawler roles to support encryption
- Remove checkov:skip comment