### PR TITLE
PR deploy branch exclusions

### DIFF
--- a/.github/workflows/pull-request-deploy-and-test.yml
+++ b/.github/workflows/pull-request-deploy-and-test.yml
@@ -7,14 +7,24 @@ on:
       - opened
       - reopened
       - synchronize
-    branches-ignore:
-      - 'dependabot/**'
-      - 'no-int-test/**'
     paths-ignore:
       - '**.md'
 
 jobs:
+  validate-deployment-or-teardown:
+    runs-on: ubuntu-latest
+    outputs:
+      valid: ${{ steps.validate.outputs.valid }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - id: validate
+        name: Validate branch eligibility for deployment
+        run: scripts/validate-deployment-or-teardown.sh ${{ github.head_ref }} >> $GITHUB_OUTPUT
+
   deploy-to-feature:
+    needs: [validate-deployment-or-teardown]
+    if: needs.validate-deployment-or-teardown.outputs.valid == 'true'
     # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
     permissions:
       id-token: write

--- a/.github/workflows/pull-request-tear-down.yml
+++ b/.github/workflows/pull-request-tear-down.yml
@@ -5,14 +5,24 @@ on:
   pull_request:
     types:
       - closed
-    branches-ignore:
-      - 'dependabot/**'
-      - 'no-int-test/**'
     paths-ignore:
       - '**.md'
 
 jobs:
+  validate-deployment-or-teardown:
+    runs-on: ubuntu-latest
+    outputs:
+      valid: ${{ steps.validate.outputs.valid }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - id: validate
+        name: Validate branch eligibility for tear down
+        run: scripts/validate-deployment-or-teardown.sh ${{ github.head_ref }} >> $GITHUB_OUTPUT
+
   tear-down-feature:
+    needs: [validate-deployment-or-teardown]
+    if: needs.validate-deployment-or-teardown.outputs.valid == 'true'
     # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
     permissions:
       id-token: write

--- a/scripts/validate-deployment-or-teardown.sh
+++ b/scripts/validate-deployment-or-teardown.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+EXCLUDED_BRANCH_PREFIXES=("dependabot/" "no-int-test/")
+
+BRANCH_NAME=$1
+
+if [ -z "$BRANCH_NAME" ]; then
+  echo "Branch name not provided"
+  echo "Usage: should-deploy-to-feature.sh BRANCH_NAME"
+  exit 1;
+fi
+
+for prefix in "${EXCLUDED_BRANCH_PREFIXES[@]}"; do
+    if [[ $BRANCH_NAME == $prefix* ]]; then
+      echo "valid=false"
+      exit 0
+    fi
+done
+
+echo "valid=true"


### PR DESCRIPTION
- Add new validate-deployment-or-teardown.sh script
- Add workflow logic to only deploy or tear down if branch validation via script is successful