### PR TITLE
Fixing the error reported by QA team - DAP 1263 DataQualityGlueStartJobRun failed due to EmptyDataFrame: DataFrame cannot be empty

### DIFF
--- a/athena-scripts/data_quality_scripts/data_quality_metrics_generation.py
+++ b/athena-scripts/data_quality_scripts/data_quality_metrics_generation.py
@@ -39,15 +39,16 @@ def athena_insert(dataframe, database, table, s3_path):
     insert dataframe into athena table
     """
     try:
-        
-        wr.s3.to_parquet(
-                        df=dataframe,
-                        path=s3_path,
-                        dataset=True,
-                        mode="append",
-                        database=database,
-                        table=table
-                    )
+
+        if not dataframe.empty:
+            wr.s3.to_parquet(
+                            df=dataframe,
+                            path=s3_path,
+                            dataset=True,
+                            mode="append",
+                            database=database,
+                            table=table
+                        )
         
         
     except Exception as e:


### PR DESCRIPTION
QA team has raised the bug - https://govukverify.atlassian.net/browse/DAC-1263. The high level error message is as follows: DataQualityGlueStartJobRun failed due to EmptyDataFrame: DataFrame cannot be empty

To fix the issue, the defensive check has been added on Glue DQ metrics Job.