### PR TITLE
Fix environments with real TxMA queues

### DIFF
--- a/iac/base.yml
+++ b/iac/base.yml
@@ -5,7 +5,7 @@ Transform: AWS::Serverless-2016-10-31
 Outputs:
   TXMAQueueURL:
     Description: 'TxMA queue URL'
-    Value: !If [UsePlaceholderTxMAQueue, !Ref EventConsumerQueue, !Ref 'AWS::NoValue']
+    Value: !If [UsePlaceholderTxMAQueue, !Ref EventConsumerQueue, '']
 
   TXMABucket:
     Description: 'Name of raw bucket'


### PR DESCRIPTION
- Fix stack failing in environments with real TxMA queues
- Error was Template format error: The Value field of every Outputs member must evaluate to a String