### PR TITLE
DAC-1313 Redshift support in test lambda

### DIFF
--- a/iac/resources/global.yml
+++ b/iac/resources/global.yml
@@ -193,11 +193,21 @@ TestSupportLambda:
           - Effect: Allow
             Action: firehose:DescribeDeliveryStream
             Resource: '*'
+          - Effect: Allow
+            Action:
+              - redshift-data:DescribeStatement
+              - redshift-data:ExecuteStatement
+              - redshift-data:GetStatementResult
+            Resource: '*'
+          - Effect: Allow
+            Action: secretsmanager:GetSecretValue
+            Resource: !Ref MyRedshiftSecret
     ReservedConcurrentExecutions: 10
     Environment:
       # checkov:skip=CKV_AWS_173: These environment variables do not require encryption
       Variables:
         ENVIRONMENT: !Ref Environment
+        REDSHIFT_SECRET_ARN: !Ref MyRedshiftSecret
     Tags:
       Environment: !Ref Environment
     VpcConfig:

--- a/sam-local-examples/env.json
+++ b/sam-local-examples/env.json
@@ -4,5 +4,8 @@
   },
   "EventConsumerLambda": {
     "FIREHOSE_STREAM_NAME": "stream-name"
+  },
+  "TestSupportLambda": {
+    "REDSHIFT_SECRET_ARN": "secret-arn"
   }
 }

--- a/sam-local-examples/test-support/athena-run-query.json
+++ b/sam-local-examples/test-support/athena-run-query.json
@@ -2,10 +2,10 @@
   "environment": "dev",
   "command": "ATHENA_RUN_QUERY",
   "input": {
-    "QueryString": "SELECT AVG(age) FROM testtable WHERE salary > 60000;",
+    "QueryString": "SELECT COUNT(*) FROM \"dev-txma-raw\".\"auth_authorisation_initiated\"",
     "QueryExecutionContext": {
-      "Database": "testdatabase"
+      "Database": "dev-txma-raw"
     },
-    "WorkGroup": "test-workgroup"
+    "WorkGroup": "dev-dap-txma-processing"
   }
 }

--- a/sam-local-examples/test-support/redshift-run-query.json
+++ b/sam-local-examples/test-support/redshift-run-query.json
@@ -1,0 +1,7 @@
+{
+  "environment": "dev",
+  "command": "REDSHIFT_RUN_QUERY",
+  "input": {
+    "Sql": "SELECT COUNT(*) FROM \"dev-redshift\".\"dev_txma_stage\".\"auth_account_creation\""
+  }
+}

--- a/src/handlers/test-support/query-runner.ts
+++ b/src/handlers/test-support/query-runner.ts
@@ -1,0 +1,102 @@
+import { logger } from './handler';
+import type { TestSupportEvent } from './handler';
+import { GetQueryExecutionCommand, GetQueryResultsCommand, StartQueryExecutionCommand } from '@aws-sdk/client-athena';
+import type { GetQueryResultsOutput } from '@aws-sdk/client-athena';
+import { getEnvironmentVariable, getRequiredParams, sleep } from '../../shared/utils/utils';
+import { athenaClient, redshiftClient } from '../../shared/clients';
+import {
+  DescribeStatementCommand,
+  ExecuteStatementCommand,
+  GetStatementResultCommand,
+} from '@aws-sdk/client-redshift-data';
+import type { GetStatementResultCommandOutput } from '@aws-sdk/client-redshift-data';
+
+export type QueryRunnerDatabaseType = 'athena' | 'redshift';
+
+interface QueryStatus {
+  status?: string;
+  extraInfo?: unknown;
+}
+
+export class QueryRunner {
+  private readonly databaseType: QueryRunnerDatabaseType;
+
+  constructor(databaseType: QueryRunnerDatabaseType) {
+    this.databaseType = databaseType;
+  }
+
+  async runQuery(event: TestSupportEvent): Promise<unknown> {
+    try {
+      const queryId = await this.startQuery(event);
+      await this.waitForQueryToSucceed(queryId, event.input.timeoutMs ?? 5000);
+      return await this.getQueryResults(queryId);
+    } catch (e) {
+      logger.error(`Error executing ${this.databaseType} query with input ${JSON.stringify(event.input)}`, { e });
+      throw e;
+    }
+  }
+
+  private async startQuery(event: TestSupportEvent): Promise<string | undefined> {
+    if (this.databaseType === 'athena') {
+      const request = new StartQueryExecutionCommand({
+        ...getRequiredParams(event.input, 'QueryString', 'QueryExecutionContext', 'WorkGroup'),
+      });
+      return await athenaClient.send(request).then(response => response.QueryExecutionId);
+    } else {
+      const request = new ExecuteStatementCommand({
+        ...getRequiredParams(event.input, 'Sql'),
+        Database: `${event.environment}-redshift`,
+        WorkgroupName: `${event.environment}-redshift-serverless-workgroup`,
+        SecretArn: getEnvironmentVariable('REDSHIFT_SECRET_ARN'),
+      });
+      return await redshiftClient.send(request).then(response => response.Id);
+    }
+  }
+
+  private async waitForQueryToSucceed(queryId: string | undefined, timeoutMs: number): Promise<void> {
+    let status: QueryStatus | undefined;
+    let timeRemaining = timeoutMs;
+    while (timeRemaining > 0) {
+      status = await this.getQueryStatus(queryId);
+
+      // return if SUCCEEDED (FINISHED for redshift) to stop waiting, break if CANCELLED (ABORTED for redshift) to allow error to be thrown
+      // don't break if FAILED as athena may retry and put back in QUEUED
+      // see https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-athena/interfaces/queryexecutionstatus.html#state-5
+      // see https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-redshift-data/interfaces/describestatementcommandoutput.html#status-1
+      if (status?.status === 'SUCCEEDED' || status?.status === 'FINISHED') {
+        return;
+      } else if (status?.status === 'CANCELLED' || status?.status === 'ABORTED') {
+        break;
+      }
+      timeRemaining -= 200;
+      await sleep(200);
+    }
+    throw new Error(`Query did not complete in ${timeoutMs}ms - final status was ${JSON.stringify(status)}`);
+  }
+
+  private async getQueryStatus(queryId: string | undefined): Promise<QueryStatus | undefined> {
+    if (this.databaseType === 'athena') {
+      return await athenaClient.send(new GetQueryExecutionCommand({ QueryExecutionId: queryId })).then(response => {
+        const status = response.QueryExecution?.Status;
+        if (status === undefined) {
+          return undefined;
+        }
+        return { status: status.State, extraInfo: { reason: status.StateChangeReason, error: status.AthenaError } };
+      });
+    } else {
+      return await redshiftClient
+        .send(new DescribeStatementCommand({ Id: queryId }))
+        .then(response => ({ status: response.Status, extraInfo: response.Error }));
+    }
+  }
+
+  private async getQueryResults(
+    queryId: string | undefined,
+  ): Promise<GetQueryResultsOutput | GetStatementResultCommandOutput> {
+    if (this.databaseType === 'athena') {
+      return await athenaClient.send(new GetQueryResultsCommand({ QueryExecutionId: queryId }));
+    } else {
+      return await redshiftClient.send(new GetStatementResultCommand({ Id: queryId }));
+    }
+  }
+}

--- a/src/shared/clients.ts
+++ b/src/shared/clients.ts
@@ -7,6 +7,7 @@ import { FirehoseClient } from '@aws-sdk/client-firehose';
 import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 import { AthenaClient } from '@aws-sdk/client-athena';
 import { SFNClient } from '@aws-sdk/client-sfn';
+import { RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 
 export const athenaClient = new AthenaClient(AWS_CLIENT_BASE_CONFIG);
 
@@ -18,6 +19,8 @@ export const firehoseClient = new FirehoseClient({
 });
 
 export const lambdaClient = new LambdaClient(AWS_CLIENT_BASE_CONFIG);
+
+export const redshiftClient = new RedshiftDataClient(AWS_CLIENT_BASE_CONFIG);
 
 export const s3Client = new S3Client(AWS_CLIENT_BASE_CONFIG);
 

--- a/src/test-resources/redshift-query-results.json
+++ b/src/test-resources/redshift-query-results.json
@@ -1,0 +1,26 @@
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "6b19fda2-7734-41cc-ad96-4d2dfe4342b8",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "ColumnMetadata": [
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": true,
+      "label": "count",
+      "length": 0,
+      "name": "count",
+      "nullable": 1,
+      "precision": 19,
+      "scale": 0,
+      "schemaName": "",
+      "tableName": "",
+      "typeName": "int8"
+    }
+  ],
+  "Records": [[{ "longValue": 1517 }]],
+  "TotalNumRows": 1
+}


### PR DESCRIPTION
- Add new redshift command to test lambda
- Extract athena query handling functionality into shared class so the redshift command can use it
- Add new test lambda handler tests and JSON to test-resources
- Add new permissions and environment variable to test lambda IaC code
- Update example JSON in sam-local-examples