### PR TITLE
Add option to delete original to test lambda S3_COPY

### DIFF
--- a/iac/resources/global.yml
+++ b/iac/resources/global.yml
@@ -160,11 +160,12 @@ TestSupportLambda:
             Resource: '*'
           - Effect: Allow
             Action:
+              - s3:DeleteObject
               - s3:GetObject
               - s3:GetBucketLocation
               - s3:ListBucket
               - s3:PutObject
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:aws:s3:::${Environment}-dap*
           - Effect: Allow
             Action: sqs:SendMessage
             Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*

--- a/sam-local-examples/test-support/s3-copy-with-delete.json
+++ b/sam-local-examples/test-support/s3-copy-with-delete.json
@@ -1,0 +1,9 @@
+{
+  "environment": "dev",
+  "command": "S3_COPY",
+  "input": {
+    "Bucket": "txma-events-dev",
+    "CopySource": "dev-dap-raw-layer/txma/AUTH_CREATE_ACCOUNT/year=2023/month=06/day=19/dev-dap-txma-delivery-stream-47-2023-06-19-08-53-05-2fa5bc22-5552-30f5-a437-d9210ace7b27.gz",
+    "DeleteOriginal": true
+  }
+}

--- a/tests/helpers/s3-helpers.ts
+++ b/tests/helpers/s3-helpers.ts
@@ -1,5 +1,5 @@
 import { getEventFilePrefix, getEventFilePrefixDayBefore, poll } from './common-helpers';
-import type { TestSupportEvent } from '../../src/handlers/test-support/handler';
+import type { S3CopyCommandResult, TestSupportEvent } from '../../src/handlers/test-support/handler';
 import { invokeTestSupportLambda } from './lambda-helpers';
 import type { ListObjectsV2CommandOutput } from '@aws-sdk/client-s3';
 import { rawdataS3BucketName } from './envHelper';
@@ -55,13 +55,19 @@ export const getS3DataFileContent = async (key: string | undefined): Promise<Rec
   return await invokeTestSupportLambda(event);
 };
 
-export const cpS3files = async (bucket: string, key: string, CopySource: string): Promise<Record<string, unknown>> => {
+export const cpS3files = async (
+  bucket: string,
+  key: string,
+  CopySource: string,
+  DeleteOriginal = false,
+): Promise<S3CopyCommandResult> => {
   const event: Omit<TestSupportEvent, 'environment'> = {
     command: 'S3_COPY',
     input: {
       Bucket: bucket,
       Key: key,
       CopySource,
+      DeleteOriginal,
     },
   };
 


### PR DESCRIPTION
- Add logic to delete original to test lambda handler S3_COPY
- Add new type for S3_COPY command to return including copy response and possible delete response
- Change cpS3files test helper to use new functionality
- Add unit test and sam local example for new functionality
- Add s3:DeleteObject permission to test lambda and restrict resource