### PR TITLE
DAC-1138 Pre merge testing

### DIFF
--- a/.github/workflows/pull-request-deploy-and-test.yml
+++ b/.github/workflows/pull-request-deploy-and-test.yml
@@ -35,11 +35,82 @@ jobs:
       environment: FEATURE
       skip-s3-upload: true
 
-  run-integration-tests:
+  wait-for-deployment-to-finish:
     needs: [deploy-to-feature]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.FEATURE_ENVIRONMENT_TEAR_DOWN_ROLE_ARN }}
+      - name: Wait for stack update to be complete
+        run: aws --region eu-west-2 cloudformation wait stack-update-complete --stack-name dap
+
+  run-integration-tests:
+    needs: [wait-for-deployment-to-finish]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Run tests
-        run: echo running tests for pr https://github.com/alphagov/di-data-analytics-platform/pull/${{ github.event.pull_request.number }}
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.FEATURE_ENVIRONMENT_TEAR_DOWN_ROLE_ARN }}
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install node packages
+        run: npm ci
+      - name: Correct environment in jest.setup.js
+        run:  sed -i 's/dev/feature/' jest.setup.js
+        # todo remove the `-- --testPathIgnorePatterns=redshift` below once redshift works in the feature environment
+      - name: Run integration tests
+        run: npm run integration-test -- --testPathIgnorePatterns=redshift
+        env:
+          ENVIRONMENT: feature
+          TXMA_BUCKET: feature-dap-raw-layer
+          TXMA_QUEUE_URL: https://sqs.eu-west-2.amazonaws.com/655068466146/feature-placeholder-txma-event-queue
+
+  run-smoke-tests:
+    needs: [wait-for-deployment-to-finish]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint (enabling the aws-actions/configure-aws-credentials action)
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.FEATURE_ENVIRONMENT_TEAR_DOWN_ROLE_ARN }}
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install node packages
+        run: npm ci
+      - name: Correct environment in jest.setup.js
+        run:  sed -i 's/dev/feature/' jest.setup.js
+      - name: Run smoke tests
+        run: npm run smoke-test
+        env:
+          ENVIRONMENT: feature
+          TXMA_BUCKET: feature-dap-raw-layer
+          TXMA_QUEUE_URL: https://sqs.eu-west-2.amazonaws.com/655068466146/feature-placeholder-txma-event-queue


### PR DESCRIPTION
- Add job to wait for deployment to finish before running tests to pull-request-deploy-and-test workflow
- Add jobs to run integration and smoke tests in pull-request-deploy-and-test workflow
- Ignore redshift integration tests until it is set up in the feature environment