### PR TITLE
Vary Quicksight session duration by environment

### DIFF
--- a/src/handlers/cognito-quicksight-access/handler.ts
+++ b/src/handlers/cognito-quicksight-access/handler.ts
@@ -2,7 +2,7 @@ import { getLogger } from '../../shared/powertools';
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import { quicksightClient } from '../../shared/clients';
 import { GenerateEmbedUrlForRegisteredUserCommand } from '@aws-sdk/client-quicksight';
-import { getEnvironmentVariable } from '../../shared/utils/utils';
+import { getAWSEnvironment, getEnvironmentVariable } from '../../shared/utils/utils';
 
 const logger = getLogger('lambda/cognito-quicksight-redirect');
 
@@ -108,6 +108,7 @@ const getEmbedUrl = async (accountId: string, username: string): Promise<string>
   const request = new GenerateEmbedUrlForRegisteredUserCommand({
     AwsAccountId: accountId,
     UserArn: userArn,
+    SessionLifetimeInMinutes: getAWSEnvironment() === 'production' ? 600 : 15,
     ExperienceConfiguration: {
       QuickSightConsole: {
         InitialPath: '/start',


### PR DESCRIPTION
- Add logic to give the maximum Quicksight duration in production and the minimum anywhere else
- Add test for new logic and extract fetch mock setup code