### PR TITLE
DAC-2681 Transfer mechanism between production and production preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The difference between them and `staging` is that the promotion bucket `integrat
 
 #### Other Environments
 
-Blah not in secure pipelines
+The following accounts are not in secure pipelines.
 
 ###### Feature
 
@@ -298,6 +298,15 @@ The _production preview_ environment is another standalone environment that exis
 It has a GitHub Action [Deploy to the production preview environment](.github/workflows/deploy-to-production-preview.yml) but no corresponding tear down one.
 
 The deployments use a special role in the _production preview_ environment, `dap-production-preview-deploy-role`, much like the role in _feature_.
+
+#### Config for cross account data sync
+
+Because _production preview_ and _staging_ are used for cross account data sync, they have a single SSM parameter holding the name of the cross account data sync role.
+They use this to allow access to their SQS queues and usage of their KMS keys to enable the cross account data sync process.
+
+| Name                        | Description                                      |
+|-----------------------------|--------------------------------------------------|
+| CrossAccountDataSyncRoleARN | ARN of the role allowing cross account data sync |
 
 ## Additional Documents
 

--- a/iac/main/base.yml
+++ b/iac/main/base.yml
@@ -88,6 +88,9 @@ Conditions:
   IsProduction: !Equals [!Ref Environment, production]
   IsProductionPreview: !Equals [!Ref Environment, production-preview]
   IsNotProductionPreview: !Not [!Equals [!Ref Environment, production-preview]]
+  IsCrossAccountDataSyncEnvironment: !Or
+    - !Condition IsStaging
+    - !Condition IsProductionPreview
   UsePlaceholderTxMAQueue: !Or
     - !Condition IsTest
     - !Condition IsFeature

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -5,6 +5,28 @@ EventConsumerQueue:
     QueueName: !Sub ${Environment}-placeholder-txma-event-queue
     KmsMasterKeyId: !GetAtt KmsKey.Arn
 
+EventConsumerQueuePolicy:
+  Type: AWS::SQS::QueuePolicy
+  Condition: IsCrossAccountDataSyncEnvironment
+  Properties:
+    PolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Sid: __owner_statement
+          Effect: Allow
+          Action: 'sqs:*'
+          Resource: !GetAtt EventConsumerQueue.Arn
+          Principal:
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+        - Sid: __sender_statement
+          Effect: Allow
+          Action: sqs:SendMessage
+          Resource: !GetAtt EventConsumerQueue.Arn
+          Principal:
+            AWS: '{{resolve:ssm:CrossAccountDataSyncRoleARN}}'
+    Queues:
+      - !Ref EventConsumerQueue
+
 EventConsumerLambda:
   # checkov:skip=CKV_AWS_116: DLQ not needed for lambda driven by SQS
   Type: AWS::Serverless::Function

--- a/iac/main/resources/global.yml
+++ b/iac/main/resources/global.yml
@@ -326,6 +326,17 @@ KmsKey:
             - kms:GenerateDataKey*
             - kms:Describe*
           Resource: '*'
+        - Condition: IsCrossAccountDataSyncEnvironment
+          Effect: Allow
+          Principal:
+            AWS: '{{resolve:ssm:CrossAccountDataSyncRoleARN}}'
+          Action:
+            - kms:Encrypt*
+            - kms:Decrypt*
+            - kms:ReEncrypt*
+            - kms:GenerateDataKey*
+            - kms:Describe*
+          Resource: '*'
 
 KmsKeyAlias:
   Type: AWS::KMS::Alias


### PR DESCRIPTION
- Add IaC to give cross account data sync role the access it needs in staging and production preview
- Add note in README about new required SSM parameter