### PR TITLE
dap-2662 -Implementation - Build the data transfer mechanism between two accounts

### DIFF
--- a/src/handlers/cross-account-transfer/handler.spec.ts
+++ b/src/handlers/cross-account-transfer/handler.spec.ts
@@ -1,0 +1,41 @@
+import { handler } from from './handler';
+
+describe('Lambda Function', () => {
+    it('should handle the Cross Account Lambda invocation correctly', async () => {
+        const event = {
+            config: [
+                {
+                    event_name: 'example_event',
+                    start_date: '2024-01-01',
+                    end_date: '2024-01-03',
+                }
+            ],
+            raw_bucket: 'your-raw-bucket-name',
+            queue_url: 'your-sqs-queue-url'
+        };
+
+        const context = {};
+
+        const result = await handler(event, context);
+
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toEqual(JSON.stringify('Messages sent to SQS successfully!'));
+    });
+
+    it('should handle error when encountering an invalid event for the cross account lambda', async () => {
+        const event = {
+            config: [
+                {}
+            ],
+            raw_bucket: 'your-raw-bucket-name',
+            queue_url: 'your-sqs-queue-url'
+        };
+
+        const context = {};
+
+        const result = await handler(event, context);
+
+        expect(result.statusCode).toBe(500);
+        expect(result.body).toEqual(JSON.stringify('Error sending messages to SQS'));
+    });
+});

--- a/src/handlers/cross-account-transfer/handler.ts
+++ b/src/handlers/cross-account-transfer/handler.ts
@@ -1,0 +1,102 @@
+import { SQSClient, SendMessageBatchCommand } from "@aws-sdk/client-sqs";
+import { S3Client, ListObjectsV2Command, GetObjectCommand } from "@aws-sdk/client-s3";
+import { createGunzip } from 'zlib';
+import { v4 as uuidv4 } from "uuid";
+
+const sqs = new SQSClient({ apiVersion: "2012-11-05", region: "eu-west-2" });
+const s3 = new S3Client({ region: "eu-west-2" });
+
+interface EventConfig {
+    event_name: string;
+    start_date: string;
+    end_date: string;
+}
+
+interface Event {
+    config: EventConfig[];
+    raw_bucket: string;
+    queue_url: string;
+}
+
+export const handler = async (event: Event) => {
+    try {
+        for (const eventConfig of event.config) {
+            const eventName = eventConfig.event_name;
+            const startDate = eventConfig.start_date;
+            const endDate = eventConfig.end_date;
+            const dateRange = generateDateRange(startDate, endDate);
+
+            for (const date of dateRange) {
+                const s3Bucket = event.raw_bucket;
+                const s3Prefix = `txma/${eventName}/year=${date.slice(0, 4)}/month=${date.slice(5, 7)}/day=${date.slice(8, 10)}`;
+                const s3Params = { Bucket: s3Bucket, Prefix: s3Prefix };
+
+                const s3Response = await s3.send(new ListObjectsV2Command(s3Params));
+
+                if (s3Response.Contents && s3Response.Contents.length > 0) {
+                    const messages = [];
+                    for (const obj of s3Response.Contents) {
+                        const getObjectParams = { Bucket: s3Bucket, Key: obj.Key };
+                        const objectResponse = await s3.send(new GetObjectCommand(getObjectParams));
+                        const objectContent = await getDecompressedContent(objectResponse);
+                        const jsonEvents = objectContent.trim().split('\n');
+
+                        for (const event of jsonEvents) {
+                            messages.push({
+                                Id: uuidv4(),
+                                MessageBody: event,
+                                MessageAttributes: {
+                                    date: { DataType: 'String', StringValue: date },
+                                    bucket: { DataType: 'String', StringValue: s3Bucket },
+                                    key: { DataType: 'String', StringValue: obj.Key }
+                                }
+                            });
+                        }
+                    }
+
+                    const batchSize = 10;
+                    const batches = [];
+                    for (let i = 0; i < messages.length; i += batchSize) {
+                        batches.push(messages.slice(i, i + batchSize));
+                    }
+
+                    console.log(`Processed ${messages.length} events for ${eventName} on ${date}`);
+
+                    for (const batch of batches) {
+                        const params = { Entries: batch, QueueUrl: event.queue_url };
+                        await sqs.send(new SendMessageBatchCommand(params));
+                    }
+                }
+            }
+        }
+
+        return { statusCode: 200, body: JSON.stringify('Messages sent to SQS successfully!') };
+    } catch (error) {
+        console.error('Error:', error);
+        return { statusCode: 500, body: JSON.stringify('Error sending messages to SQS') };
+    }
+};
+
+async function getDecompressedContent(objectResponse: any): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const chunks: Uint8Array[] = [];
+        const decompressor = createGunzip();
+        objectResponse.Body.pipe(decompressor);
+
+        decompressor.on('data', (chunk: Uint8Array) => { chunks.push(chunk); });
+        decompressor.on('end', () => { resolve(Buffer.concat(chunks).toString('utf-8')); });
+        decompressor.on('error', (error: any) => { reject(error); });
+    });
+}
+
+function generateDateRange(startDate: string, endDate: string): string[] {
+    const dateRange: string[] = [];
+    let currentDate = new Date(startDate);
+
+    while (currentDate <= new Date(endDate)) {
+        dateRange.push(currentDate.toISOString().slice(0, 10));
+        currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return dateRange;
+}


### PR DESCRIPTION
The data transfer mechanism has been described on the page - https://govukverify.atlassian.net/wiki/spaces/DAP/pages/3975577970/Data+Transfer+Mechanism+between+Accounts.

Initial approach:

take data from raw layer on source account

extract data from the event-level folder in raw 

copy events to new location which would be destination account