### PR TITLE
DAC-2922 Manual reference data ingestion pipeline part 1

### DIFF
--- a/iac/main/resources/manual-reference-data-ingestion.yml
+++ b/iac/main/resources/manual-reference-data-ingestion.yml
@@ -1,0 +1,29 @@
+RedshiftGetMetadataLambda:
+  # checkov:skip=CKV_AWS_116: DLQ not needed as this lambda failing will cause state machine to fail
+  Type: AWS::Serverless::Function
+  Properties:
+    FunctionName: !Sub redshift-get-metadata-${Environment}
+    Handler: redshift-get-metadata.handler
+    Policies:
+      - AWSLambdaBasicExecutionRole
+      - Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:ListBucket
+            Resource: !Sub ${ELTMetadataBucket.Arn}/*
+    ReservedConcurrentExecutions: 10
+    Environment:
+      # checkov:skip=CKV_AWS_173: These environment variables do not require encryption
+      Variables:
+        ENVIRONMENT: !Ref Environment
+        METADATA_BUCKET_NAME: !Ref ELTMetadataBucket
+    Tags:
+      Environment: !Ref Environment
+    VpcConfig:
+      SecurityGroupIds:
+        - !Ref LambdaSecurityGroup
+      SubnetIds:
+        - !Ref SubnetForDAP1
+        - !Ref SubnetForDAP2
+        - !Ref SubnetForDAP3

--- a/src/handlers/redshift-get-metadata/handler.spec.ts
+++ b/src/handlers/redshift-get-metadata/handler.spec.ts
@@ -1,0 +1,138 @@
+import type { RedshiftConfig, RedshiftExtractMetadataEvent } from './handler';
+import { handler } from './handler';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import { getTestResource, mockS3BodyStream } from '../../shared/utils/test-utils';
+
+const mockS3Client = mockClient(S3Client);
+
+const METADATA_BUCKET_NAME = 'dev-dap-elt-metadata';
+
+let TEST_EVENT: RedshiftExtractMetadataEvent;
+
+let TEST_CONFIG_FILE: string;
+
+beforeAll(async () => {
+  TEST_EVENT = {
+    fileMetadata: {
+      bucket: METADATA_BUCKET_NAME,
+      file_path: 'reference-data/data_analytics/benefits_dashboard/20240305/account_login_2024-03-05_22-12-04.csv',
+    },
+  };
+  TEST_CONFIG_FILE = await getTestResource('redshift-metadata-config.json');
+});
+
+beforeEach(() => {
+  mockS3Client.reset();
+  mockS3Client.callsFake(input => {
+    throw new Error(`Unexpected S3 request - ${JSON.stringify(input)}`);
+  });
+
+  process.env.METADATA_BUCKET_NAME = METADATA_BUCKET_NAME;
+});
+
+test('bad input events', async () => {
+  mockS3Client.resolves({});
+
+  const missingBucket = { fileMetadata: { file_path: 'file_path' } } as unknown as RedshiftExtractMetadataEvent;
+  await expect(handler(missingBucket)).rejects.toThrow('Object is missing the following required fields: bucket');
+
+  const missingFilePath = { fileMetadata: { bucket: 'bucket' } } as unknown as RedshiftExtractMetadataEvent;
+  await expect(handler(missingFilePath)).rejects.toThrow('Object is missing the following required fields: file_path');
+
+  const missingBoth = { fileMetadata: {} } as unknown as RedshiftExtractMetadataEvent;
+  await expect(handler(missingBoth)).rejects.toThrow(
+    'Object is missing the following required fields: bucket, file_path',
+  );
+
+  await expect(handler(null as unknown as RedshiftExtractMetadataEvent)).rejects.toThrow('Object is null or undefined');
+  await expect(handler(undefined as unknown as RedshiftExtractMetadataEvent)).rejects.toThrow(
+    'Object is null or undefined',
+  );
+  await expect(handler({} as unknown as RedshiftExtractMetadataEvent)).rejects.toThrow('Object is null or undefined');
+  await expect(handler({ fileMetadata: null } as unknown as RedshiftExtractMetadataEvent)).rejects.toThrow(
+    'Object is null or undefined',
+  );
+  await expect(handler({ fileMetadata: undefined } as unknown as RedshiftExtractMetadataEvent)).rejects.toThrow(
+    'Object is null or undefined',
+  );
+
+  expect(mockS3Client.calls()).toHaveLength(0);
+});
+
+test('missing bucket name', async () => {
+  process.env.METADATA_BUCKET_NAME = '';
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow('METADATA_BUCKET_NAME is not defined in this environment');
+
+  expect(mockS3Client.calls()).toHaveLength(0);
+});
+
+test('file parts parse error', async () => {
+  const badFilePath = 'bad/path.csv';
+  const badFilePathEvent: RedshiftExtractMetadataEvent = {
+    fileMetadata: { bucket: METADATA_BUCKET_NAME, file_path: badFilePath },
+  };
+
+  await expect(handler(badFilePathEvent)).rejects.toThrow(`Unable to parse key path string "${badFilePath}"`);
+
+  expect(mockS3Client.calls()).toHaveLength(0);
+});
+
+test('s3 error', async () => {
+  const error = 's3 error';
+  mockS3Client.rejects(error);
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow(error);
+
+  expect(mockS3Client.calls()).toHaveLength(1);
+});
+
+test('json parse error', async () => {
+  const badJson = 'hi';
+  mockS3Client.resolves({ Body: mockS3BodyStream({ stringValue: badJson }) });
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow(
+    `Error parsing JSON string "${badJson}" - Unexpected token h in JSON at position 0`,
+  );
+
+  expect(mockS3Client.calls()).toHaveLength(1);
+});
+
+test('config object errors', async () => {
+  const helloWorld = { hello: 'world' };
+  mockS3Client
+    .resolvesOnce({ Body: mockS3BodyStream({ stringValue: JSON.stringify(helloWorld, null, 2) }) })
+    .resolvesOnce({
+      Body: mockS3BodyStream({
+        stringValue: JSON.stringify({ benefits_dashboard: { data_sources: helloWorld } }, null, 2),
+      }),
+    });
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow(`Cannot read properties of undefined (reading 'data_sources')`);
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow(
+    `Cannot read properties of undefined (reading 'redshift_metadata')`,
+  );
+
+  expect(mockS3Client.calls()).toHaveLength(2);
+});
+
+test('success', async () => {
+  // test first of the file path parts (data_analytics) indirectly by only resolving for a GetObjectCommand with it properly within the Key
+  mockS3Client
+    .on(GetObjectCommand, {
+      Bucket: METADATA_BUCKET_NAME,
+      Key: 'reference_data/configuration_files/data_analytics_reference_data_configuration.json',
+    })
+    .resolvesOnce({ Body: mockS3BodyStream({ stringValue: TEST_CONFIG_FILE }) });
+
+  // test second and third of the file path parts (benefits_dashboard and account_login) indirectly as they should have led to the right bit of JSON being returned
+  const response = await handler(TEST_EVENT);
+  expect(response).toBeDefined();
+
+  const parsedFile: RedshiftConfig = JSON.parse(TEST_CONFIG_FILE);
+  expect(response).toEqual(parsedFile.benefits_dashboard.data_sources.account_login.redshift_metadata);
+
+  expect(mockS3Client.calls()).toHaveLength(1);
+});

--- a/src/shared/utils/utils.spec.ts
+++ b/src/shared/utils/utils.spec.ts
@@ -66,6 +66,16 @@ test('get required params errors if field present but null or undefined', () => 
   );
 });
 
+test('get required params errors if object is null or undefined', () => {
+  expect(() => getRequiredParams(null as unknown as Record<string, unknown>, 'Bucket')).toThrow(
+    'Object is null or undefined',
+  );
+
+  expect(() => getRequiredParams(undefined as unknown as Record<string, unknown>, 'Bucket')).toThrow(
+    'Object is null or undefined',
+  );
+});
+
 test('encode and decode', () => {
   const testObject = { a: 'b', c: true, d: 42 };
 

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -21,6 +21,10 @@ export const getRequiredParams = <T extends Record<string, any>, K extends keyof
   t: T,
   ...requiredParams: K[]
 ): Required<Pick<T, K>> => {
+  if (t === null || t === undefined) {
+    throw new Error('Object is null or undefined');
+  }
+
   const missingFields = requiredParams.filter(field => !(field in t) || t[field] === null || t[field] === undefined);
   if (missingFields.length !== 0) {
     throw new Error(`Object is missing the following required fields: ${missingFields.join(', ')}`);

--- a/src/test-resources/redshift-metadata-config.json
+++ b/src/test-resources/redshift-metadata-config.json
@@ -1,0 +1,25 @@
+{
+  "benefits_dashboard": {
+    "data_sources": {
+      "account_login": {
+        "ingestion_enabled_status": true,
+        "redshift_metadata": {
+          "database": "demo_reference_data_db",
+          "schema": "reference_data",
+          "table": "account_login",
+          "operation": "overwrite"
+        }
+      },
+      "online_id_verification": {
+        "ingestion_enabled_status": true,
+        "redshift_metadata": {
+          "database": "demo_reference_data_db",
+          "schema": "reference_data",
+          "table": "online_id_verification",
+          "operation": "append"
+        }
+      }
+    }
+  },
+  "metadata_columns": ["source_file_name", "ingestion_datetime", "process_id"]
+}


### PR DESCRIPTION
- Add lambda handler, tests and test resource for redshift get metadata
- Add IaC for new redshift get metadata function
- Add null and undefined checks to getRequiredParams util and update utils tests