### PR TITLE
DAC-3236 Manual reference data ingestion pipeline part 7

### DIFF
--- a/iac/main/resources/manual-reference-data-ingestion.yml
+++ b/iac/main/resources/manual-reference-data-ingestion.yml
@@ -475,8 +475,6 @@ DLQLambda:
       # checkov:skip=CKV_AWS_173: These environment variables do not require encryption
       Variables:
         ENVIRONMENT: !Ref Environment
-        METADATA_BUCKET_NAME: !Ref ELTMetadataBucket
-        STAGE_BUCKET_NAME: !Ref StageLayerBucket
     Tags:
       Environment: !Ref Environment
     VpcConfig:
@@ -500,3 +498,34 @@ VPCEndpointEventBridge:
       - !Ref SubnetForDAP1
       - !Ref SubnetForDAP2
       - !Ref SubnetForDAP3
+
+StepFunctionValidationLambda:
+  # checkov:skip=CKV_AWS_116: DLQ not appropriate as this lambda receives events from the DLQ
+  Type: AWS::Serverless::Function
+  Properties:
+    FunctionName: !Sub stepfunction-validate-execution-${Environment}
+    Handler: stepfunction-validate-execution.handler
+    Policies:
+      - AWSLambdaBasicExecutionRole
+      - Statement:
+          - Effect: Allow
+            Action: states:DescribeExecution
+            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:${ProcessReferenceDataStateMachine.Name}:*
+          - Effect: Allow
+            Action: states:ListExecutions
+            Resource: !Ref ProcessReferenceDataStateMachine
+    ReservedConcurrentExecutions: 10
+    Environment:
+      # checkov:skip=CKV_AWS_173: These environment variables do not require encryption
+      Variables:
+        ENVIRONMENT: !Ref Environment
+        STATE_MACHINE_ARN: !Ref ProcessReferenceDataStateMachine
+    Tags:
+      Environment: !Ref Environment
+    VpcConfig:
+      SecurityGroupIds:
+        - !Ref LambdaSecurityGroup
+      SubnetIds:
+        - !Ref SubnetForDAP1
+        - !Ref SubnetForDAP2
+        - !Ref SubnetForDAP3

--- a/src/handlers/stepfunction-validate-execution/handler.spec.ts
+++ b/src/handlers/stepfunction-validate-execution/handler.spec.ts
@@ -1,0 +1,140 @@
+import { mockClient } from 'aws-sdk-client-mock';
+import { DescribeExecutionCommand, ListExecutionsCommand, SFNClient } from '@aws-sdk/client-sfn';
+import type { ExecutionListItem, ExecutionStatus } from '@aws-sdk/client-sfn';
+import { handler } from './handler';
+
+const mockSFNClient = mockClient(SFNClient);
+
+const EXECUTION_ARN =
+  'arn:aws:states:eu-west-2:123456789012:execution:state-machine:88b36f26-bc23-4525-8749-857f9646ca4d';
+
+const MESSAGE_GROUP_ID = 'benefits_data_government_services';
+
+const STATE_MACHINE_ARN = 'arn:aws:states:eu-west-2:123456789012:stateMachine:state-machine';
+
+const TEST_EVENT = {
+  currentExecutionArn: EXECUTION_ARN,
+  messageGroupId: MESSAGE_GROUP_ID,
+};
+
+beforeEach(() => {
+  mockSFNClient.reset();
+  mockSFNClient.callsFake(input => {
+    throw new Error(`Unexpected SFN request - ${JSON.stringify(input)}`);
+  });
+
+  process.env.STATE_MACHINE_ARN = STATE_MACHINE_ARN;
+});
+
+test('missing state machine arn', async () => {
+  process.env.STATE_MACHINE_ARN = '';
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow('STATE_MACHINE_ARN is not defined in this environment');
+
+  expect(mockSFNClient.calls()).toHaveLength(0);
+});
+
+test('no executions', async () => {
+  mockSetup();
+
+  const response = await handler(TEST_EVENT);
+  expect(response).toEqual({ continue: 'true' });
+
+  // one for the execution list
+  expect(mockSFNClient.calls()).toHaveLength(1);
+});
+
+test('old execution with same id', async () => {
+  mockSetup({ running: false, sameId: true });
+
+  const response = await handler(TEST_EVENT);
+  expect(response).toEqual({ continue: 'true' });
+
+  // one for the execution list
+  expect(mockSFNClient.calls()).toHaveLength(1);
+});
+
+test('running execution not with same id', async () => {
+  mockSetup({ running: true, sameId: false }, { running: false, sameId: false });
+
+  const response = await handler(TEST_EVENT);
+  expect(response).toEqual({ continue: 'true' });
+
+  // one for the execution list and one for the description of the running execution
+  expect(mockSFNClient.calls()).toHaveLength(2);
+});
+
+test('running execution with same id', async () => {
+  mockSetup({ running: true, sameId: true }, { running: false, sameId: false });
+
+  const response = await handler(TEST_EVENT);
+  expect(response).toEqual({ continue: 'false' });
+
+  // one for the execution list and one for the description of the running execution
+  expect(mockSFNClient.calls()).toHaveLength(2);
+});
+
+test('multiple running executions with same id', async () => {
+  mockSetup(
+    { running: true, sameId: true },
+    { running: false, sameId: false },
+    { running: true, sameId: false },
+    { running: true, sameId: true },
+  );
+
+  const response = await handler(TEST_EVENT);
+  expect(response).toEqual({ continue: 'false' });
+
+  // one for the execution list and three for the description of the running executions
+  expect(mockSFNClient.calls()).toHaveLength(4);
+});
+
+test('sfn client error', async () => {
+  const errorMessage = 'sfn error';
+  mockSFNClient.on(ListExecutionsCommand).rejects(errorMessage);
+
+  await expect(handler(TEST_EVENT)).rejects.toThrow(errorMessage);
+
+  expect(mockSFNClient.calls()).toHaveLength(1);
+});
+
+const mockSetup = (...extraExecutions: { running: boolean; sameId: boolean }[]) => {
+  const executions = [executionListItem()].concat(
+    extraExecutions.map((e, i) => executionListItem(`arn:${i}`, e.running ? 'RUNNING' : 'SUCCEEDED')),
+  );
+  mockSFNClient.on(ListExecutionsCommand, { stateMachineArn: STATE_MACHINE_ARN }).resolvesOnce({ executions });
+
+  const descriptions = extraExecutions.map((e, i) => ({
+    stateMachineArn: STATE_MACHINE_ARN,
+    executionArn: `arn:${i}`,
+    input: e.sameId ? executionInput() : executionInput(`extra-${i}`),
+  }));
+  descriptions.forEach(description =>
+    mockSFNClient.on(DescribeExecutionCommand, { executionArn: description.executionArn }).resolvesOnce(description),
+  );
+};
+
+const executionListItem = (executionArn = EXECUTION_ARN, status: ExecutionStatus = 'SUCCEEDED'): ExecutionListItem => {
+  return {
+    stateMachineArn: STATE_MACHINE_ARN,
+    executionArn: executionArn,
+    status,
+  } as unknown as ExecutionListItem;
+};
+
+const executionInput = (messageGroupId = MESSAGE_GROUP_ID): string => {
+  return JSON.stringify([
+    {
+      messageId: 'id',
+      attributes: {
+        ApproximateReceiveCount: '1',
+        SentTimestamp: '1711111584399',
+        SequenceNumber: '18204784639205694620',
+        MessageGroupId: messageGroupId,
+        SenderId: 'KJSYTFJSMD2JPQMNS4NCV:s3-send-metadata',
+        MessageDeduplicationId: `${messageGroupId}_2024-03-22_12-46-17`,
+        ApproximateFirstReceiveTimestamp: '1711111584399',
+      },
+    },
+  ]);
+};

--- a/src/handlers/stepfunction-validate-execution/handler.ts
+++ b/src/handlers/stepfunction-validate-execution/handler.ts
@@ -1,0 +1,60 @@
+import { getLogger } from '../../shared/powertools';
+import { sfnClient } from '../../shared/clients';
+import { ensureDefined, getEnvironmentVariable } from '../../shared/utils/utils';
+import { DescribeExecutionCommand, ListExecutionsCommand } from '@aws-sdk/client-sfn';
+
+const logger = getLogger('lambda/stepfunction-validate-execution');
+
+interface ValidateExecutionEvent {
+  currentExecutionArn: string;
+  messageGroupId: string;
+}
+
+interface ValidateExecutionResponse {
+  continue: 'true' | 'false';
+}
+
+export const handler = async (event: ValidateExecutionEvent): Promise<ValidateExecutionResponse> => {
+  try {
+    const stateMachineArn = getEnvironmentVariable('STATE_MACHINE_ARN');
+    logger.info('Validating stepfunction execution', { event, stateMachineArn });
+
+    const currentExecutionArns = await getCurrentExecutionArns(event, stateMachineArn);
+    const executingWithSameId = await getExecutingWithSameId(event, currentExecutionArns);
+    if (executingWithSameId.length > 0) {
+      logger.error('One or more other executions found with the same MessageGroupId', { executingWithSameId });
+      return { continue: 'false' };
+    } else {
+      return { continue: 'true' };
+    }
+  } catch (error) {
+    logger.error('Error validating stepfunction execution', { error });
+    throw error;
+  }
+};
+
+const getCurrentExecutionArns = async (event: ValidateExecutionEvent, stateMachineArn: string): Promise<string[]> => {
+  const request = new ListExecutionsCommand({ stateMachineArn });
+  const executions = await sfnClient.send(request).then(response => response.executions ?? []);
+  return executions
+    .filter(execution => execution.status === 'RUNNING' || execution.status === 'PENDING_REDRIVE') // only get running or about to run
+    .map(execution => ensureDefined(() => execution.executionArn)) // ensure defined
+    .filter(executionArn => executionArn !== event.currentExecutionArn); // only get ones that are not the current execution from the lambda event
+};
+
+const getExecutingWithSameId = async (event: ValidateExecutionEvent, executionArns: string[]): Promise<string[]> => {
+  const executingWithSameId: string[] = [];
+  for (const executionArn of executionArns) {
+    const executionInput = await getExecutionInput(executionArn);
+    const parsedInput = JSON.parse(executionInput);
+    if (parsedInput?.at(0)?.attributes?.MessageGroupId === event.messageGroupId) {
+      executingWithSameId.push(executionArn);
+    }
+  }
+  return executingWithSameId;
+};
+
+const getExecutionInput = async (executionArn: string): Promise<string> => {
+  const request = new DescribeExecutionCommand({ executionArn });
+  return await sfnClient.send(request).then(response => ensureDefined(() => response.input));
+};


### PR DESCRIPTION
- Add new stepfunction validate execution lambda handler and tests
- Add IaC for new function
- Remove unneeded environment variables from IaC for dlq to eventbridge function