### PR TITLE
update upload testing image job for new ADM model tests

### DIFF
--- a/.github/workflows/upload-testing-image.yml
+++ b/.github/workflows/upload-testing-image.yml
@@ -50,7 +50,7 @@ jobs:
           IMAGE_NAME: dap-${{ inputs.test-type }}-tests
           IMAGE_TAG: latest
         run: |
-          docker build -f tests/${{ inputs.test-type }}-tests/scripts/Dockerfile -t $IMAGE_NAME:$IMAGE_TAG .
+          docker build -f tests/${{ inputs.test-type }}-tests-restructuring/scripts/Dockerfile -t $IMAGE_NAME:$IMAGE_TAG .
           docker tag $IMAGE_NAME:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/tests/smoke-tests-restructuring/scripts/Dockerfile
+++ b/tests/smoke-tests-restructuring/scripts/Dockerfile
@@ -43,14 +43,14 @@ RUN aws --version
 COPY tests ./tests
 COPY scripts ./scripts
 COPY package.json package-lock.json tsconfig.json ./
-COPY tests/smoke-tests/scripts/jest.smoke.config.js ./jest.config.js
-COPY tests/smoke-tests/scripts/jest.smoke.setup.js ./jest.setup.js
+COPY tests/smoke-tests-restructuring/scripts/jest.smoke.config.js ./jest.config.js
+COPY tests/smoke-tests-restructuring/scripts/jest.smoke.setup.js ./jest.setup.js
 COPY src/handlers/test-support/ ./src/handlers/test-support/
 COPY src/shared/ ./src/shared/
 
 RUN npm ci
 
-WORKDIR /test-app/tests/smoke-tests/scripts
+WORKDIR /test-app/tests/smoke-tests-restructuring/scripts
 
 RUN mv ./run-smoke-tests.sh /run-tests.sh
 RUN chmod +x /run-tests.sh

--- a/tests/smoke-tests-restructuring/scripts/jest.smoke.config.js
+++ b/tests/smoke-tests-restructuring/scripts/jest.smoke.config.js
@@ -1,7 +1,7 @@
 module.exports = async () => {
   return {
-    roots: ['<rootDir>/tests/smoke-tests'],
-    testMatch: ['**/tests/smoke-tests/*.spec.ts'],
+    roots: ['<rootDir>/tests/smoke-tests-restructuring'],
+    testMatch: ['**/tests/smoke-tests-restructuring/*.spec.ts'],
     coveragePathIgnorePatterns: ['/node_modules/'],
     // globalSetup: "./src/handlers/int-test-support/helpers/testSetup.ts",
     testTimeout: 300000,

--- a/tests/smoke-tests-restructuring/scripts/run-smoke-tests.sh
+++ b/tests/smoke-tests-restructuring/scripts/run-smoke-tests.sh
@@ -13,7 +13,7 @@ cd /test-app || exit 1
 export TXMA_QUEUE_URL=$CFN_TXMAQueueURL
 export TXMA_BUCKET=$CFN_TXMABucket
 
-npm run smoke-test
+npm run smoke-test-restructuring
 
 TESTS_EXIT_CODE=$?
 


### PR DESCRIPTION
Since decommissioning the old ADM model, we have found that the pipeline was running tests on the old model which was failing because it didn't exist anymore

This PR ensures the testing images that are uploaded to ECR are for the new model hence the suffix 'restructuring'


