### PR TITLE
esbuild-jest removal fixes

### DIFF
--- a/docs/development-decisions.md
+++ b/docs/development-decisions.md
@@ -48,7 +48,7 @@ Usage can be seen in the [build-lambdas.sh](../scripts/build-lambdas.sh) script.
 Unit testing is done with [Jest](https://jestjs.io) which is commonly used in GDS, and used in the BTM and TxMA repositories.
 
 [Configuration for Jest](https://jestjs.io/docs/configuration) can be found in the [jest.config.ts](../jest.config.js) file at the top-level,
-and is pretty trivial in that is merely sets a verbosity setting (in line with TxMA) and tells jest to use the `esbuild-jest` to convert the code to JavaScript.
+and is pretty trivial in that is merely sets a verbosity setting (in line with TxMA) and tells jest to use `@swc/jest` to convert the code to JavaScript.
 
 ## SAM Template
 

--- a/tests/e2e-tests-restructuring/scripts/jest.e2e.config.js
+++ b/tests/e2e-tests-restructuring/scripts/jest.e2e.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/e2e-tests/scripts/jest.e2e.config.js
+++ b/tests/e2e-tests/scripts/jest.e2e.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/integration-tests-restructuring/scripts/jest.integration.config.js
+++ b/tests/integration-tests-restructuring/scripts/jest.integration.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/integration-tests/scripts/jest.integration.config.js
+++ b/tests/integration-tests/scripts/jest.integration.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/prod-smoke-tests-restructuring/scripts/jest.smoke.config.js
+++ b/tests/prod-smoke-tests-restructuring/scripts/jest.smoke.config.js
@@ -6,7 +6,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/prod-smoke-tests/scripts/jest.smoke.config.js
+++ b/tests/prod-smoke-tests/scripts/jest.smoke.config.js
@@ -6,7 +6,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/smoke-tests-restructuring/scripts/jest.smoke.config.js
+++ b/tests/smoke-tests-restructuring/scripts/jest.smoke.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',

--- a/tests/smoke-tests/scripts/jest.smoke.config.js
+++ b/tests/smoke-tests/scripts/jest.smoke.config.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     testTimeout: 300000,
     verbose: true,
     transform: {
-      '^.+\\.tsx?$': 'esbuild-jest',
+      '^.+\\.tsx?$': '@swc/jest',
     },
     collectCoverage: true,
     testResultsProcessor: 'jest-junit',


### PR DESCRIPTION
- Update all jest configs under tests/ directory to use new @swc library for transforming
- Update development-decisions reference to esbuild-jest
- Add type annotations to run flyway command lambda test now we are not using esbuild-jest