### PR TITLE
Flyway improvements

### DIFF
--- a/.github/workflows/run-flyway-command.yml
+++ b/.github/workflows/run-flyway-command.yml
@@ -12,7 +12,7 @@ on:
         type: choice
         required: true
         description: Flyway command to run
-        options: [info, migrate, validate, clean]
+        options: [info, migrate, validate, repair, clean]
       database:
         type: string
         required: true

--- a/redshift-scripts/flyway/README.md
+++ b/redshift-scripts/flyway/README.md
@@ -37,6 +37,19 @@ Library files for Flyway (library itself and the Redshift JAR). These can be lef
 
 Migration files for Flyway. For more on the concept, refer to the documentation [here](https://documentation.red-gate.com/flyway/flyway-cli-and-api/concepts/migrations).
 
+### `flyway.conf`
+
+Config file for flyway. We set some properties in the lambda as environment variables, but set the following static properties in the `flyway.conf` file.
+For more on the config file see the documentation [here](https://www.red-gate.com/hub/product-learning/flyway/the-flyway-configuration-files)
+
+- `flyway.defaultSchema` - the schema where flyway will put its history table. we give it its own
+  schema to do this
+- `flyway.schemas` - list of schemas flyway manages. it will try and create them if they don't exist in an empty database, and it will clean them all when the `clean` command is run.
+  The `migrate` command will operate from the default schema so all schema references must be explicit.
+  If we didn't set a default schema, flyway would use the first schema in this list as the default one
+
+See the documentation [here](https://www.red-gate.com/hub/product-learning/flyway/the-flyway-configuration-files#schemas) for more on these schema options
+
 #### Database subdirectories
 
 Note that all migration files are under subdirectories of the `migrations/` directory. These subdirectories are the names of databases in Redshift.

--- a/redshift-scripts/flyway/flyway.conf
+++ b/redshift-scripts/flyway/flyway.conf
@@ -1,0 +1,2 @@
+flyway.defaultSchema=flyway
+flyway.schemas=audit_refactored,conformed_refactored,presentation_refactored,reference_data

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/R__grants_for_procedure.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/R__grants_for_procedure.sql
@@ -1,14 +1,3 @@
-GRANT EXECUTE ON procedure conformed_refactored.update_dap_data_mart() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.dim_event_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.dim_journey_channel_refactored_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.dim_relying_party_refactored_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.dim_user_journey_event_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.dim_user_refactored_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.event_extensions_refactored_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.fact_user_journey_event_refactored_upsert() TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.redshift_date_dim(VARCHAR,VARCHAR) TO "IAMR:production-dap-redshift-processing-role";
-GRANT EXECUTE ON procedure conformed_refactored.update_event_batch_table() TO "IAMR:production-dap-redshift-processing-role";
-
 GRANT ALL ON DATABASE "dap_txma_reporting_db_refactored" TO GROUP dap_elt_processing;
 GRANT ALL ON SCHEMA "conformed_refactored" TO GROUP dap_elt_processing;
 GRANT ALL ON ALL TABLES IN SCHEMA "conformed_refactored" TO GROUP dap_elt_processing;

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V3.0__create_reference_data_schema.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V3.0__create_reference_data_schema.sql
@@ -1,1 +1,1 @@
-create schema if not exists dap_txma_reporting_db_refactored.reference_data;
+create schema if not exists reference_data;

--- a/redshift-scripts/setup_process_refactored/redshift_setup_process_scripts_refactored.sql
+++ b/redshift-scripts/setup_process_refactored/redshift_setup_process_scripts_refactored.sql
@@ -48,15 +48,26 @@ CREATE GROUP dap_elt_processing;
 Create IAM user (used by the Redshift Step Function)
 --**REPLACE {env}**
 */
-
---**REPLACE {env}**
 CREATE USER "IAMR:{env}-dap-redshift-processing-role" PASSWORD DISABLE;
-
+ALTER GROUP dap_elt_processing ADD USER "IAMR:{env}-dap-redshift-processing-role";
 
 /*
  IMPORTANT: Run flyway scripts to add all stored procedures in to redshift, see redshift-scripts/flyway/README.md for details
 */
 
+/*
+Grants for IAM user
+ */
+GRANT EXECUTE ON procedure conformed_refactored.update_dap_data_mart() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.dim_event_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.dim_journey_channel_refactored_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.dim_relying_party_refactored_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.dim_user_journey_event_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.dim_user_refactored_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.event_extensions_refactored_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.fact_user_journey_event_refactored_upsert() TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.redshift_date_dim(VARCHAR,VARCHAR) TO "IAMR:{env}-dap-redshift-processing-role";
+GRANT EXECUTE ON procedure conformed_refactored.update_event_batch_table() TO "IAMR:{env}-dap-redshift-processing-role";
 
 /*
 Database object privileges to group
@@ -67,11 +78,11 @@ GRANT ALL ON SCHEMA "audit" TO GROUP dap_elt_processing;
 GRANT ALL ON ALL TABLES IN SCHEMA "audit" TO GROUP dap_elt_processing;
 GRANT USAGE ON SCHEMA "dap_txma_stage" TO GROUP dap_elt_processing;
 
-
 /*
 Database object privileges to group
 */
 
 GRANT ALL ON DATABASE "dap_txma_reporting_db_refactored" TO GROUP dap_elt_processing;
 GRANT ALL ON SCHEMA "audit_refactored" TO GROUP dap_elt_processing;
+GRANT ALL ON SCHEMA "conformed_refactored" TO GROUP dap_elt_processing;
 GRANT ALL ON ALL TABLES IN SCHEMA "audit_refactored" TO GROUP dap_elt_processing;

--- a/src/handlers/run-flyway-command/handler.spec.ts
+++ b/src/handlers/run-flyway-command/handler.spec.ts
@@ -38,7 +38,6 @@ const expectedEnvironment = (event: { database: string }, cleanDisabled: boolean
     FLYWAY_LOCATIONS: `filesystem:/tmp/flyway/migrations/${event.database}`,
     FLYWAY_CONFIG_FILES: '/tmp/flyway/flyway.conf',
     FLYWAY_CLEAN_DISABLED: cleanDisabled.toString(),
-    FLYWAY_DEFAULT_SCHEMA: 'flyway',
   });
 };
 

--- a/src/handlers/run-flyway-command/handler.ts
+++ b/src/handlers/run-flyway-command/handler.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 
 const logger = getLogger('lambda/run-flyway-command');
 
-const FLYWAY_COMMANDS = ['clean', 'info', 'migrate', 'validate'];
+const FLYWAY_COMMANDS = ['clean', 'info', 'migrate', 'repair', 'validate'];
 
 const LAMBDA_FILES_ROOT = '/tmp/flyway';
 
@@ -25,7 +25,7 @@ const LIBRARY_FILES_PATH = `${LAMBDA_FILES_ROOT}/lib`;
 
 type FlywayCommand = (typeof FLYWAY_COMMANDS)[number];
 
-interface RunFlywayEvent {
+export interface RunFlywayEvent {
   command: FlywayCommand;
   database: string;
 }
@@ -146,7 +146,6 @@ const getFlywayEnvironment = async (
   FLYWAY_LOCATIONS: `filesystem:${MIGRATIONS_DIRECTORY_PATH}/${event.database}`,
   FLYWAY_CONFIG_FILES: CONFIG_FILE_PATH,
   FLYWAY_CLEAN_DISABLED: getAWSEnvironment() === 'production' ? 'true' : 'false',
-  FLYWAY_DEFAULT_SCHEMA: 'flyway',
 });
 
 const runFlywayCommand = (event: RunFlywayEvent, environment: Record<string, string>): RunFlywayResult => {


### PR DESCRIPTION
- Add flyway schemas to flyway.conf file
- Move flyway defaultSchema to flyway.conf file
- Add section on flyway.conf file to the flyway README
- Remove database qualifier in previous migration as it no longer works
- Add repair to the list of valid flyway commands in the lambda
- Add extra commands to redshift setup process script
- Remove some hardcoded grants from repeatable migration that are already in redshift setup process script