### PR TITLE
Silence all backfill job failures

### DIFF
--- a/raw-to-stage/raw_to_stage_etl/raw_to_stage_process_glue_job.py
+++ b/raw-to-stage/raw_to_stage_etl/raw_to_stage_process_glue_job.py
@@ -17,6 +17,8 @@ from raw_to_stage_etl.strategies.scheduled_strategy import ScheduledStrategy
 from raw_to_stage_etl.strategies.view_strategy import ViewStrategy
 from raw_to_stage_etl.util.data_preprocessing import DataPreprocessing
 from raw_to_stage_etl.util.exceptions.util_exceptions import OperationFailedException
+from raw_to_stage_etl.util.exceptions.util_exceptions import QueryException
+
 from raw_to_stage_etl.util.json_config_processing_utilities import extract_element_by_name
 
 logger = get_logger(__name__)
@@ -91,7 +93,7 @@ def main():
             processor = RawToStageProcessor(args, backfill_strategy)
             try:
                 processor.process()
-            except (NoDataFoundException, OperationFailedException) as e:
+            except (NoDataFoundException, OperationFailedException, QueryException) as e:
                 logger.info("Exception Message: %s, Stacktrace: %s", str(e), traceback.format_exc())
                 # as no data could be found for backfill, supress the exception
                 logger.info("Exiting without raising error(As no data could be found for backfill)")

--- a/raw-to-stage/raw_to_stage_etl/strategies/backfill_strategy.py
+++ b/raw-to-stage/raw_to_stage_etl/strategies/backfill_strategy.py
@@ -111,10 +111,6 @@ class BackfillStrategy(Strategy):
             self.max_processed_dt,
             penultimate_processed_dt,
         )
-
-        if min_timestamp_filter_for_missing_events is None:
-            raise OperationFailedException("Could not calculate a minimum timestamp to filter for missing events, ending process")
-
         self.logger.info("retrieved timestamp filter value: %s", self.max_timestamp)
 
         backfill_raw_sql = self.get_raw_sql(


### PR DESCRIPTION
Backfill job should swallow all failures so that it doesn't fail the entire process
