### PR TITLE
No int test/dpt 1229 ipv int address duplicate

### DIFF
--- a/.github/workflows/run-flyway-command.yml
+++ b/.github/workflows/run-flyway-command.yml
@@ -72,5 +72,5 @@ jobs:
           PAYLOAD=$(echo "{\"command\": \"${{ inputs.command }}\", \"database\": \"${{ inputs.database }}\"}")
           echo "$PAYLOAD" | jq
           ENCODED=$(echo "$PAYLOAD" | openssl base64)
-          aws --region eu-west-2 lambda invoke --function-name run-flyway-command --payload "$ENCODED" out.json
+          aws --region eu-west-2 --cli-read-timeout 600 lambda invoke --function-name run-flyway-command --payload "$ENCODED" out.json
           cat out.json | jq

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -1,16 +1,3 @@
---Take backup first
-create table "conformed_refactored"."fact_user_journey_event_refactored_bkp_ipv_duplicate_issue_new"
-AS
-select * from "conformed_refactored"."fact_user_journey_event_refactored";
-
-create table "conformed_refactored"."event_extensions_refactored_bkp_ipv_duplicate_issue_new"
-AS
-select * from "conformed_refactored"."event_extensions_refactored";
-
-create table "conformed_refactored"."batch_events_refactored_bkp_ipv_duplicate_issue_new"
-AS
-select * from "conformed_refactored"."batch_events_refactored";
-
 
 --delete from fact
 

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -25,25 +25,11 @@ where event_name='IPV_INTERNATIONAL_ADDRESS_START')
 
 
 -- delete duplicate entery 
-WITH ranked_events AS (
-    SELECT event_name, 
-           insert_timestamp,
-           ROW_NUMBER() OVER (
-               PARTITION BY event_name 
-               ORDER BY insert_timestamp DESC
-           ) AS row_num
-    FROM "conformed_refactored"."batch_events_refactored"
-    WHERE event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
-)
 DELETE FROM "conformed_refactored"."batch_events_refactored"
-WHERE (event_name, insert_timestamp) IN (
-    SELECT event_name, insert_timestamp
-    FROM ranked_events
-    WHERE row_num = 1
-);
-
-
---reset the batch start date to ingest clean data.
-update "conformed_refactored"."batch_events_refactored"
-set max_run_date='1999-01-01'
 where event_name='IPV_INTERNATIONAL_ADDRESS_START';
+
+--reset the event
+
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('IPV_INTERNATIONAL_ADDRESS_START',sysdate,'1999-01-01');
+
+

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -1,9 +1,4 @@
---As these scripts takes too long to run you need to run them manually. This will also run a dummy
---sql insert so flayway keeps a track of this change.
-
-select * from "conformed_refactored"."batch_events_refactored";
-
-/*--Take backup first
+--Take backup first
 create table "conformed_refactored"."fact_user_journey_event_refactored_bkp_ipv_duplicate_issue"
 AS
 select * from "conformed_refactored"."fact_user_journey_event_refactored";
@@ -61,4 +56,3 @@ WHERE (event_name, insert_timestamp) IN (
     FROM ranked_events
     WHERE row_num = 1
 );
-*/

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -1,15 +1,3 @@
-
---delete from fact
-
-DELETE FROM "conformed_refactored"."fact_user_journey_event_refactored"
-WHERE event_id IN (
-    SELECT fct.event_id
-    FROM "conformed_refactored"."fact_user_journey_event_refactored" fct
-    JOIN "conformed_refactored"."dim_event_refactored" de
-    ON fct.event_key = de.event_key
-    WHERE de.event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
-);
-
 --delete from extensions table
 
 DELETE FROM "conformed_refactored"."event_extensions_refactored"
@@ -22,6 +10,18 @@ on fct.event_id=ext.event_id
 join conformed_refactored.dim_event_refactored de
 on fct.event_key=de.event_key
 where event_name='IPV_INTERNATIONAL_ADDRESS_START')
+
+
+--delete from fact
+
+DELETE FROM "conformed_refactored"."fact_user_journey_event_refactored"
+WHERE event_id IN (
+    SELECT fct.event_id
+    FROM "conformed_refactored"."fact_user_journey_event_refactored" fct
+    JOIN "conformed_refactored"."dim_event_refactored" de
+    ON fct.event_key = de.event_key
+    WHERE de.event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
+);
 
 
 -- delete duplicate entery 

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -1,4 +1,9 @@
---Take backup first
+--As these scripts takes too long to run you need to run them manually. This will also run a dummy
+--sql insert so flayway keeps a track of this change.
+
+select * from "conformed_refactored"."batch_events_refactored";
+
+/*--Take backup first
 create table "conformed_refactored"."fact_user_journey_event_refactored_bkp_ipv_duplicate_issue"
 AS
 select * from "conformed_refactored"."fact_user_journey_event_refactored";
@@ -56,3 +61,4 @@ WHERE (event_name, insert_timestamp) IN (
     FROM ranked_events
     WHERE row_num = 1
 );
+*/

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -9,7 +9,7 @@ join conformed_refactored.event_extensions_refactored ext
 on fct.event_id=ext.event_id
 join conformed_refactored.dim_event_refactored de
 on fct.event_key=de.event_key
-where event_name='IPV_INTERNATIONAL_ADDRESS_START')
+where event_name='IPV_INTERNATIONAL_ADDRESS_START');
 
 
 --delete from fact
@@ -30,6 +30,7 @@ where event_name='IPV_INTERNATIONAL_ADDRESS_START';
 
 --reset the event
 
-insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('IPV_INTERNATIONAL_ADDRESS_START',sysdate,'1999-01-01');
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) 
+values ('IPV_INTERNATIONAL_ADDRESS_START',sysdate,'1999-01-01');
 
 

--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.12__ipv-int-address-issue-duplicate-issue.sql
@@ -1,0 +1,58 @@
+--Take backup first
+create table "conformed_refactored"."fact_user_journey_event_refactored_bkp_ipv_duplicate_issue"
+AS
+select * from "conformed_refactored"."fact_user_journey_event_refactored";
+
+create table "conformed_refactored"."event_extensions_refactored_bkp_ipv_duplicate_issue"
+AS
+select * from "conformed_refactored"."event_extensions_refactored";
+
+create table "conformed_refactored"."batch_events_refactored_bkp_ipv_duplicate_issue"
+AS
+select * from "conformed_refactored"."batch_events_refactored";
+
+
+--delete from fact
+
+WITH duplicates AS (
+    SELECT fct.user_journey_event_key
+    FROM "conformed_refactored"."fact_user_journey_event_refactored" fct
+    JOIN "conformed_refactored"."dim_event_refactored" de
+        ON fct.event_key = de.event_key
+    WHERE de.event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
+    --AND fct.event_id = 'e77e2b91-530d-416b-a93f-ac02b2610548'
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY fct.event_id ORDER BY fct.created_date DESC) = 2
+)
+DELETE FROM "conformed_refactored"."fact_user_journey_event_refactored"
+WHERE user_journey_event_key IN (SELECT user_journey_event_key FROM duplicates);
+
+--delete from extensions 
+
+WITH fact_filtered AS (
+    -- Select relevant fact records by joining with dim_event_refactored on event_name
+    SELECT f.user_journey_event_key, f.event_id
+    FROM "conformed_refactored"."fact_user_journey_event_refactored" f
+    JOIN "conformed_refactored"."dim_event_refactored" d
+        ON f.event_key = d.event_key
+    WHERE d.event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
+)
+DELETE FROM "conformed_refactored"."event_extensions_refactored"
+WHERE event_id IN (SELECT event_id FROM fact_filtered)  -- Match event_id
+AND user_journey_event_key NOT IN (SELECT user_journey_event_key FROM fact_filtered);
+
+WITH ranked_events AS (
+    SELECT event_name, 
+           insert_timestamp,
+           ROW_NUMBER() OVER (
+               PARTITION BY event_name 
+               ORDER BY insert_timestamp DESC
+           ) AS row_num
+    FROM "conformed_refactored"."batch_events_refactored"
+    WHERE event_name = 'IPV_INTERNATIONAL_ADDRESS_START'
+)
+DELETE FROM "conformed_refactored"."batch_events_refactored"
+WHERE (event_name, insert_timestamp) IN (
+    SELECT event_name, insert_timestamp
+    FROM ranked_events
+    WHERE row_num = 1
+);


### PR DESCRIPTION
This is the bug fix for DPT-1229. IPV_INTERNATIONAL_ADDRESS_START was enabled twice and due to that issue the data in the fact/extensions table was duplicated. I have removed all the data for this event from fact/extensions tables. Data will  be reloaded again.