### PR TITLE
use redshift secret as db user to refresh views

### DIFF
--- a/iac/main/resources/state-machine.yml
+++ b/iac/main/resources/state-machine.yml
@@ -703,6 +703,10 @@ StepFunctionRedshiftProcessRole:
                 - events:PutTargets
                 - events:PutRule
                 - events:DescribeRule
+            - Effect: Allow
+              Resource: !Ref RedshiftSecret
+              Action:
+                - secretsmanager:GetSecretValue
 
 TxmaRawLayerConsolidatedSchemaProcessingStateMachine:
   Type: AWS::Serverless::StateMachine # More info about State Machine Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
@@ -910,6 +914,7 @@ ADMConsolidatedModelProcessingStateMachine:
       RedshiftWorkgroup: !Ref RedshiftServerlessWorkgroup
       RedshiftDatabaseName: dap_txma_reporting_db_refactored
       StateMachineResultsBucket: !Ref StateMachineResultsBucket
+      RedshiftSecretArn: !Ref RedshiftSecret
 
 SplunkMigratedRawStageTransformProcessPythonGlueJob:
   Type: AWS::Glue::Job

--- a/iac/main/resources/state-machine.yml
+++ b/iac/main/resources/state-machine.yml
@@ -704,7 +704,7 @@ StepFunctionRedshiftProcessRole:
                 - events:PutRule
                 - events:DescribeRule
             - Effect: Allow
-              Resource: !Ref RedshiftSecret
+              Resource: '*'
               Action:
                 - secretsmanager:GetSecretValue
 

--- a/iac/main/resources/state-machine.yml
+++ b/iac/main/resources/state-machine.yml
@@ -704,7 +704,7 @@ StepFunctionRedshiftProcessRole:
                 - events:PutRule
                 - events:DescribeRule
             - Effect: Allow
-              Resource: '*'
+              Resource: !Sub 'arn:aws:secretsmanager:eu-west-2:${AWS::AccountId}:secret:*'
               Action:
                 - secretsmanager:GetSecretValue
 

--- a/statemachine/txma_adm_consolidated_schema_processing.asl.json
+++ b/statemachine/txma_adm_consolidated_schema_processing.asl.json
@@ -37,7 +37,7 @@
       "Parameters": {
         "WorkgroupName": "${RedshiftWorkgroup}",
         "Database": "${RedshiftDatabaseName}",
-        "SecretArn": "${RedshiftSecret}",
+        "SecretArn": "${RedshiftSecretArn}",
         "Sql": "call presentation_refactored.refresh_adm_views()"
       },
       "Next": "wait_on_adm_refresh_update"

--- a/statemachine/txma_adm_consolidated_schema_processing.asl.json
+++ b/statemachine/txma_adm_consolidated_schema_processing.asl.json
@@ -37,6 +37,7 @@
       "Parameters": {
         "WorkgroupName": "${RedshiftWorkgroup}",
         "Database": "${RedshiftDatabaseName}",
+        "SecretArn": "${RedshiftSecret}",
         "Sql": "call presentation_refactored.refresh_adm_views()"
       },
       "Next": "wait_on_adm_refresh_update"


### PR DESCRIPTION
Since deploying https://govukverify.atlassian.net/jira/software/c/projects/DPT/boards/604?assignee=712020%3A45f9d3ac-fef5-4372-97b9-620ad222d6c2&selectedIssue=DPT-1232

We've seen that the adm refresh failed due to insufficient access rights to Refresh views since only owners of the view can refresh it. There doesn't seem to be any obvious solution to give db level grant permissions in redshift to allow the IAM user to refresh views so this makes sure that the step function uses the admin db user and password to refresh views