### PR TITLE
updated to RP prod

### DIFF
--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.13__Mobile_Wallet_events_inserts_dpt_972.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.13__Mobile_Wallet_events_inserts_dpt_972.sql
@@ -1,0 +1,2 @@
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('WALLET_CREDENTIAL_ADD_ATTEMPT',sysdate,'1999-01-01');
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('WALLET_CREDENTIAL_ADDED',sysdate,'1999-01-01');


### PR DESCRIPTION
Enabling mobile wallet events to DAP for ingestion i.e. WALLET_CREDENTIAL_ADD_ATTEMPT and WALLET_CREDENTIAL_ADDED.