### PR TITLE
No int test/dpt 877 mobile id check events

### DIFF
--- a/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.16__Mobile_ID_Check_events_inserts_dpt_877.sql
+++ b/redshift-scripts/flyway/migrations/dap_txma_reporting_db_refactored/V5.16__Mobile_ID_Check_events_inserts_dpt_877.sql
@@ -1,0 +1,4 @@
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED',sysdate,'1999-01-01');
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('DCMAW_ASYNC_CRI_4XXERROR',sysdate,'1999-01-01');
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('DCMAW_ASYNC_CRI_5XXERROR',sysdate,'1999-01-01');
+insert into conformed_refactored.batch_events_refactored (event_name,insert_timestamp,max_run_date) values ('DCMAW_ASYNC_APP_END',sysdate,'1999-01-01');


### PR DESCRIPTION
Enabling 4 new mobile ID check events for DAP.