### PR TITLE
dpt-1784 wait increased to 120 seconds from 5

### DIFF
--- a/statemachine/txma_redshift_consolidated_schema_processing.asl.json
+++ b/statemachine/txma_redshift_consolidated_schema_processing.asl.json
@@ -44,7 +44,7 @@
     "wait_on_dap_datamart_update": {
       "Comment": "Wait before status check",
       "Type": "Wait",
-      "Seconds": 5,
+      "Seconds": 120,
       "Next": "dap_datamart_update_status_check"
     },
     "dap_datamart_update_status_check": {


### PR DESCRIPTION
DAP Step function is failing intermittently as it reaches 25000 history events due to a loop which polls status every 5 seconds. Increased polling interval from 5 seconds to 120 seconds

March 31st - 8,153 history events - 01:28 hours runtime - 994,058 records
June 24th -23,993 history events - 04:15 hours runtime -  8,894,009 records