### PR TITLE
DPT-1909 Testing that build fails when unit tests fail

### DIFF
--- a/raw-to-stage/raw_to_stage_etl/strategies/scheduled_strategy.py
+++ b/raw-to-stage/raw_to_stage_etl/strategies/scheduled_strategy.py
@@ -33,7 +33,7 @@ class ScheduledStrategy(Strategy):
 
         if self.max_timestamp is None:
             raise ValueError("Function 'get_max_timestamp' returned None, which is not allowed.")
-        self.logger.info("Retrieved timestamp filter value: %s", self.max_timestamp)
+        self.logger.info("retrieved timestamp filter value is: %s", self.max_timestamp)
 
         """Firehose buffer time is 15 mins.So we subtract 20 mins from the max timestamp which ensures every run will
            look for events with a timestamp higher than that value. This is to catch any events which might have flown

--- a/raw-to-stage/tests/processor/test_raw_to_stage_processor.py
+++ b/raw-to-stage/tests/processor/test_raw_to_stage_processor.py
@@ -27,6 +27,6 @@ def test_correct_strategy_methods_called(strategy_cls):
 
     mock_strategy.extract.assert_called_once()
     args, _ = mock_strategy.transform.call_args
-    pd.testing.assert_frame_equal(args[0], test_dfs['raw_df'])
+    pd.testing.assert_frame_equal(args[0], test_dfs['stage_df'])
     args, _ = mock_strategy.load.call_args
     pd.testing.assert_frame_equal(args[0], test_dfs['stage_layer_df'])


### PR DESCRIPTION
DPT-1909
Changed a line to make unit tests fail to validate that deployment will fail if the unit tests fail
Also changed a line in logs to validate that changes have not gone through to build env