### PR TITLE
update eventsourcemapping to scale with higher batch size

### DIFF
--- a/iac/main/base.yml
+++ b/iac/main/base.yml
@@ -146,6 +146,9 @@ Globals:
     Runtime: nodejs22.x
     Timeout: 30
     CodeUri: dist/
+    MemorySize: 1024
+    Architectures:
+      - arm64
     Environment:
       Variables:
         NODE_OPTIONS: '--enable-source-maps'

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -46,7 +46,6 @@ EventConsumerLambda:
               Action: kms:decrypt
               Resource: '{{resolve:ssm:TxMAKMSKeyARN}}'
             - !Ref AWS::NoValue
-    MemorySize: 1024
     Environment:
       # checkov:skip=CKV_AWS_173: These environment variables do not require encryption
       Variables:


### PR DESCRIPTION
https://govukverify.atlassian.net/jira/software/c/projects/DPT/boards/604?assignee=712020%3A45f9d3ac-fef5-4372-97b9-620ad222d6c2&selectedIssue=DPT-2224

This PR increases batch size to 10, removes reserved concurrency allowing the consumer lambda to scale to match SQS demand. It also increases lambda memory capacity to 1gb