### PR TITLE
remove arch from global

### DIFF
--- a/iac/main/base.yml
+++ b/iac/main/base.yml
@@ -149,8 +149,6 @@ Globals:
     Timeout: 30
     CodeUri: dist/
     MemorySize: 1024
-    Architectures:
-      - arm64
     Environment:
       Variables:
         NODE_OPTIONS: '--enable-source-maps'

--- a/iac/main/resources/athena.yml
+++ b/iac/main/resources/athena.yml
@@ -72,6 +72,8 @@ AthenaGetConfigLambda:
   Properties:
     FunctionName: !Sub athena-get-config-${Environment}
     Handler: athena-get-config.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:
@@ -101,6 +103,8 @@ AthenaGetStatementLambda:
   Properties:
     FunctionName: !Sub athena-get-statement-${Environment}
     Handler: athena-get-statement.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -15,6 +15,8 @@ EventConsumerLambda:
   Properties:
     FunctionName: txma-event-consumer
     Handler: txma-event-consumer.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:

--- a/iac/main/resources/global.yml
+++ b/iac/main/resources/global.yml
@@ -147,6 +147,8 @@ S3NotificationsLoggerLambda:
   Properties:
     FunctionName: !Sub s3-notifications-logger-${Environment}
     Handler: s3-notifications-logger.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
     ReservedConcurrentExecutions: 10
@@ -210,6 +212,8 @@ TestSupportLambda:
   Properties:
     FunctionName: !Sub test-support-${Environment}
     Handler: test-support.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:

--- a/iac/main/resources/manual-reference-data-ingestion.yml
+++ b/iac/main/resources/manual-reference-data-ingestion.yml
@@ -3,6 +3,8 @@ RedshiftGetMetadataLambda:
   Properties:
     FunctionName: !Sub redshift-get-metadata-${Environment}
     Handler: redshift-get-metadata.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:
@@ -240,6 +242,8 @@ S3SendMetadataLambda:
   Properties:
     FunctionName: !Sub s3-send-metadata-${Environment}
     Handler: s3-send-metadata.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:
@@ -288,6 +292,8 @@ S3RawToStagingLambda:
   Properties:
     FunctionName: !Sub s3-raw-to-staging-${Environment}
     Handler: s3-raw-to-staging.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:
@@ -445,6 +451,8 @@ DLQLambda:
   Type: AWS::Serverless::Function
   Properties:
     FunctionName: !Sub dlq-to-eventbridge-${Environment}
+    Architectures:
+      - arm64
     Events:
       ReceiveFromDLQ:
         Type: SQS
@@ -513,6 +521,8 @@ StepFunctionValidationLambda:
   Properties:
     FunctionName: !Sub stepfunction-validate-execution-${Environment}
     Handler: stepfunction-validate-execution.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:

--- a/iac/main/resources/redshift.yml
+++ b/iac/main/resources/redshift.yml
@@ -269,6 +269,8 @@ RunFlywayCommandLambda:
   # checkov:skip=CKV_AWS_116: DLQ not needed
   Type: AWS::Serverless::Function
   Properties:
+    Architectures:
+      - x86_64
     FunctionName: run-flyway-command
     Handler: run-flyway-command.handler
     Policies:
@@ -300,8 +302,6 @@ RunFlywayCommandLambda:
         REDSHIFT_SECRET_ID: !Ref RedshiftSecret
         FLYWAY_FILES_BUCKET_NAME: !Ref FlywayFilesBucket
         ENVIRONMENT: !Ref Environment
-    Architectures:
-      - x86_64
     Tags:
       Environment: !Ref Environment
     MemorySize: 4096
@@ -451,6 +451,8 @@ RedshiftCreateSnapshotLambda:
   Properties:
     FunctionName: redshift-create-snapshot
     Handler: redshift-create-snapshot.handler
+    Architectures:
+      - arm64
     Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:


### PR DESCRIPTION
We have to remove architectures from the global since it can not be overridden from cfn