### PR TITLE
Add event onboarding e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,9 @@ Running `npm run test:integration` will run all tests concurrently in two projec
 E2E tests validate the full data pipeline from event ingestion through to the conform layer in the _staging_ environment. They send events through event-processing and verify the data arrives correctly in the conform layer, ensuring it has been processed successfully by both self serve and DAP.
 
 There are two types of BAU E2E tests:
-* **RP Onboarding** — verifies that a new relying party's events are correctly reflected in the Redshift dim and ref tables
-* **Event Onboarding** — verifies that a new event type is processed and lands in the conform layer correctly (coming soon)
+* **RP Onboarding** — verifies that a new relying party's events are correctly reflected in the conform layer dim and ref tables
+* **Event Onboarding** — verifies that a new event type is processed and lands in the conform layer dim and fact journey tables correctly
 
-A daily E2E test to validate the full end-to-end flow will also be added in the future.
 
 ###### RP Onboarding
 
@@ -224,6 +223,37 @@ npm run test:e2e:rp-onboarding:check-only
 ```
 
 The test output includes a comparison table showing expected vs actual values for each client_id. Mismatched columns are highlighted in red with a summary below the table.
+
+###### Event Onboarding
+
+The event onboarding test verifies that when a new event type flows through the full pipeline, it lands correctly in the Redshift conform layer tables. The test sends the full raw event payload, and asserts that core fields (`event_id`, `component_id`, `event_name`, `user_govuk_signin_journey_id`, `date`) match in the conform layer. It also prints `user_id` (which is hashed upstream by event-processing), `channel_name`, and any extensions found for visibility.
+
+Prerequisites:
+* Set up ~/.aws/config file with the correct AWS credentials
+* Login to AWS:
+  ```sh
+  export AWS_PROFILE=data-dap-staging
+  aws sso login
+  ```
+
+Test configuration is in [tests/e2e-tests/config/event-onboarding.config.ts](tests/e2e-tests/config/event-onboarding.config.ts). Each entry is the full raw event payload — `event_id`, `timestamp` and `event_timestamp_ms` are generated automatically at send time. To test a new event type, add the raw event to the `eventOnboardingTestEvents` array — see the comments in that file for examples.
+
+There are two ways to run the test:
+
+```sh
+# Full run — sends events to SQS, waits for pipeline processing, then checks conform layer
+# Takes ~25 minutes due to event processing and ETL execution
+npm run test:e2e:event-onboarding
+```
+
+The full run output includes a comparison table showing expected vs actual values, with mismatched columns highlighted in red. Additional fields (user_id, channel_name, extensions) are printed below the table for reference.
+
+```sh
+# Check only by event_name — looks up the latest row for each event_name
+EVENT_ONBOARDING_EVENT_NAMES=EVCS_IDENTITY_REPLACED npm run test:e2e:event-onboarding:check-only
+```
+
+The check-only command prints the most recent conform layer row for each event name, including extensions.
 
 #### Test reports
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
     "test:integration:main": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/integration-tests/jest.config.main-test-suite.ts --runInBand",
     "test:integration:raw-to-stage-unhappy": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/integration-tests/jest.config.raw-to-stage-unhappy-path.ts --runInBand",
     "test:e2e:rp-onboarding": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.rp-onboarding.ts --runInBand",
-    "test:e2e:rp-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.rp-onboarding-check-only.ts --runInBand"
+    "test:e2e:rp-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.rp-onboarding-check-only.ts --runInBand",
+    "test:e2e:event-onboarding": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.event-onboarding.ts --runInBand",
+    "test:e2e:event-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.event-onboarding-check-only.ts --runInBand"
   },
   "lint-staged": {
     "*": "prettier --write",

--- a/tests/e2e-tests/config/event-onboarding.config.ts
+++ b/tests/e2e-tests/config/event-onboarding.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Event Onboarding E2E Test Configuration
+ *
+ * This test sends full raw events through the pipeline and verifies they land
+ * correctly in the conform layer. Events are sent exactly as provided (with an
+ * auto-generated event_id added), so you can validate that fields like extensions
+ * are correctly included or excluded by the pipeline.
+ *
+ * TO TEST A NEW EVENT TYPE:
+ * Add the full raw event payload to the eventOnboardingTestEvents array below.
+ * event_id, timestamp and event_timestamp_ms will be added automatically.
+ *
+ * The test asserts the following fields in the conform layer, derived from the event:
+ * - component_id from event.component_id
+ * - event_name from event.event_name
+ * - user_govuk_signin_journey_id from event.user.govuk_signin_journey_id
+ * - user_id from event.user.user_id
+ * - date from the date the test is run
+ *
+ * The test also prints (without asserting) the channel_name and any extensions
+ * found in the conform layer for visibility.
+ */
+
+import { AuditEvent } from '../../../common/types/event';
+
+export type EventOnboardingTestEvent = Omit<AuditEvent, 'event_id' | 'timestamp'>;
+
+export const eventOnboardingTestEvents: EventOnboardingTestEvent[] = [
+  // ──── Example event ────
+  // {
+  //   event_name: 'YOUR_EVENT_NAME',
+  //   component_id: 'https://your-component-id',
+  //   extensions: {
+  //     some_field: 'some_value',
+  //   },
+  //   user: {
+  //     user_id: 'urn:uuid:your-user-id',
+  //     govuk_signin_journey_id: 'your-journey-id',
+  //   },
+  // },
+  // ──── Add new events below this line ────
+];

--- a/tests/e2e-tests/helpers/utils/conform-layer-results.ts
+++ b/tests/e2e-tests/helpers/utils/conform-layer-results.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-console */
+import { executeRedshiftQuery } from '../../../shared-test-code/aws/redshift/execute-redshift-query';
+import { ExpectedConformData } from './derive-expected';
+
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+
+interface ConformResult {
+  row: Record<string, string | number> | undefined;
+  extensions: Record<string, string | number>[];
+}
+
+const CONFORM_BASE_QUERY = `SELECT
+         f.event_id,
+         f.component_id,
+         de.event_name,
+         duj.user_govuk_signin_journey_id,
+         dd.date,
+         du.user_id,
+         djc.channel_name
+       FROM conformed_refactored.fact_user_journey_event_refactored f
+       LEFT JOIN conformed_refactored.dim_event_refactored de ON f.event_key = de.event_key
+       LEFT JOIN conformed_refactored.dim_user_journey_event_refactored duj ON f.user_journey_key = duj.user_journey_key
+       LEFT JOIN conformed_refactored.dim_date_refactored dd ON f.date_key = dd.date_key
+       LEFT JOIN conformed_refactored.dim_user_refactored du ON f.user_key = du.user_key
+       LEFT JOIN conformed_refactored.dim_journey_channel_refactored djc ON f.journey_channel_key = djc.journey_channel_key`;
+
+const queryExtensions = async (eventId: string) =>
+  executeRedshiftQuery(
+    `SELECT parent_attribute_name, event_attribute_name, event_attribute_value
+     FROM conformed_refactored.event_extensions_refactored
+     WHERE event_id = '${eventId}'`,
+  );
+
+export const queryConformLayer = async (eventId: string): Promise<ConformResult> => {
+  const [rows, extensions] = await Promise.all([
+    executeRedshiftQuery(`${CONFORM_BASE_QUERY} WHERE f.event_id = '${eventId}'`),
+    queryExtensions(eventId),
+  ]);
+  return { row: rows[0], extensions };
+};
+
+export const queryConformLayerByEventName = async (eventName: string): Promise<ConformResult> => {
+  const rows = await executeRedshiftQuery(
+    `${CONFORM_BASE_QUERY} WHERE de.event_name = '${eventName}' ORDER BY dd.date DESC LIMIT 1`,
+  );
+  const row = rows[0];
+  const extensions = row?.event_id ? await queryExtensions(String(row.event_id)) : [];
+  return { row, extensions };
+};
+
+export const printConformResults = (
+  eventName: string,
+  eventId: string,
+  expected: ExpectedConformData,
+  result: ConformResult,
+): string[] => {
+  const { row, extensions } = result;
+  const mismatches: string[] = [];
+
+  const columns = ['event_id', 'component_id', 'event_name', 'journey_id', 'date'] as const;
+  const expectedRow = [
+    expected.event_id,
+    expected.component_id,
+    expected.event_name,
+    expected.user_govuk_signin_journey_id,
+    expected.date,
+  ];
+  const actualRow = [
+    String(row?.event_id ?? ''),
+    String(row?.component_id ?? ''),
+    String(row?.event_name ?? ''),
+    String(row?.user_govuk_signin_journey_id || ''),
+    String(row?.date ?? ''),
+  ];
+
+  const widths = columns.map((col, i) => Math.max(col.length, expectedRow[i].length, actualRow[i].length));
+
+  const label = '          ';
+  const separator = '─'.repeat(label.length) + '┼' + widths.map(w => '─'.repeat(w + 2)).join('┼');
+  const header = label + '│' + columns.map((col, i) => ` ${col.padEnd(widths[i])} `).join('│');
+
+  const expectedLine =
+    'Expected'.padEnd(label.length) + '│' + expectedRow.map((v, i) => ` ${v.padEnd(widths[i])} `).join('│');
+
+  const actualCells = actualRow.map((v, i) => {
+    const match = v === expectedRow[i];
+    if (!match) mismatches.push(columns[i]);
+    const padded = ` ${v.padEnd(widths[i])} `;
+    return match ? green(padded) : red(padded);
+  });
+  const allMatch = mismatches.length === 0;
+  const actualLine = 'Actual'.padEnd(label.length) + '│' + actualCells.join('│') + `  ${allMatch ? '✅' : '❌'}`;
+
+  const lines = [
+    `\n📋 ${eventName} (${eventId})`,
+    `  ${header}`,
+    `  ${separator}`,
+    `  ${expectedLine}`,
+    `  ${actualLine}`,
+  ];
+
+  if (mismatches.length > 0) {
+    lines.push(`\n  ⚠️  Mismatched: ${mismatches.join(', ')}`);
+  }
+
+  lines.push('');
+  lines.push(`  user_id: ${row?.user_id ?? '(not found)'} (hashed)`);
+  lines.push(`  channel_name: ${row?.channel_name ?? '(not found)'}`);
+
+  if (extensions.length === 0) {
+    lines.push('  extensions: none');
+  } else {
+    extensions.forEach((ext, i) => {
+      const prefix = i === 0 ? '  extensions: ' : '              ';
+      lines.push(`${prefix}${ext.parent_attribute_name}.${ext.event_attribute_name} = "${ext.event_attribute_value}"`);
+    });
+  }
+
+  console.log(lines.join('\n'));
+  return mismatches;
+};
+
+export const printConformCheckOnly = (eventName: string, result: ConformResult) => {
+  const { row, extensions } = result;
+
+  const fields = ['event_id', 'component_id', 'event_name', 'user_govuk_signin_journey_id', 'date'] as const;
+  const values = fields.map(f => String(row?.[f] ?? ''));
+  const widths = fields.map((f, i) => Math.max(f.length, values[i].length));
+
+  const header = fields.map((f, i) => ` ${f.padEnd(widths[i])} `).join('│');
+  const separator = widths.map(w => '─'.repeat(w + 2)).join('┼');
+  const valueLine = values.map((v, i) => ` ${v.padEnd(widths[i])} `).join('│');
+
+  const lines = [
+    `\n📋 ${eventName}`,
+    `  ${header}`,
+    `  ${separator}`,
+    `  ${valueLine}`,
+    '',
+    `  user_id: ${row?.user_id ?? '(not found)'} (hashed)`,
+    `  channel_name: ${row?.channel_name ?? '(not found)'}`,
+  ];
+
+  if (extensions.length === 0) {
+    lines.push('  extensions: none');
+  } else {
+    extensions.forEach((ext, i) => {
+      const prefix = i === 0 ? '  extensions: ' : '              ';
+      lines.push(`${prefix}${ext.parent_attribute_name}.${ext.event_attribute_name} = "${ext.event_attribute_value}"`);
+    });
+  }
+
+  console.log(lines.join('\n'));
+};

--- a/tests/e2e-tests/helpers/utils/derive-expected.ts
+++ b/tests/e2e-tests/helpers/utils/derive-expected.ts
@@ -1,0 +1,25 @@
+import { EventOnboardingTestEvent } from '../../config/event-onboarding.config';
+
+export interface ExpectedConformData {
+  event_id: string;
+  component_id: string;
+  event_name: string;
+  user_govuk_signin_journey_id: string;
+  date: string;
+}
+
+export const deriveExpected = (
+  event: EventOnboardingTestEvent,
+  eventId: string,
+  expectedDate: string,
+): ExpectedConformData => {
+  const user = event.user as { govuk_signin_journey_id?: string } | undefined;
+
+  return {
+    event_id: eventId,
+    component_id: String(event.component_id ?? ''),
+    event_name: String(event.event_name),
+    user_govuk_signin_journey_id: user?.govuk_signin_journey_id || '',
+    date: expectedDate,
+  };
+};

--- a/tests/e2e-tests/jest.config.event-onboarding-check-only.ts
+++ b/tests/e2e-tests/jest.config.event-onboarding-check-only.ts
@@ -1,0 +1,23 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest',
+  verbose: true,
+  testMatch: ['**/tests/e2e-tests/test-suites/event-onboarding-check-only/**/*.spec.ts'],
+  globalSetup: '<rootDir>/setup-event-onboarding-check-only.ts',
+  testTimeout: 600000,
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        suiteName: 'Event Onboarding e2e tests (check only)',
+        outputDirectory: '<rootDir>/reports',
+        ancestorSeparator: ',',
+        includeConsoleOutput: true,
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/tests/e2e-tests/jest.config.event-onboarding.ts
+++ b/tests/e2e-tests/jest.config.event-onboarding.ts
@@ -1,0 +1,23 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest',
+  verbose: true,
+  testMatch: ['**/tests/e2e-tests/test-suites/event-onboarding/**/*.spec.ts'],
+  globalSetup: '<rootDir>/setup-event-onboarding.ts',
+  testTimeout: 600000,
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        suiteName: 'Event Onboarding e2e tests',
+        outputDirectory: '<rootDir>/reports',
+        ancestorSeparator: ',',
+        includeConsoleOutput: true,
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/tests/e2e-tests/setup-event-onboarding-check-only.ts
+++ b/tests/e2e-tests/setup-event-onboarding-check-only.ts
@@ -1,0 +1,19 @@
+import { AWS_REGION, STACK_NAME } from '../shared-test-code/constants';
+import { grantRedshiftAccess } from '../shared-test-code/aws/redshift/grant-access';
+import { setE2EEnvVarsFromSsm } from './helpers/config/ssm-config';
+import { getE2ETestEnv } from './helpers/utils/utils';
+
+export default async function globalSetup() {
+  process.env.STACK_NAME = process.env.STACK_NAME ?? STACK_NAME;
+  process.env.AWS_REGION = process.env.AWS_REGION ?? AWS_REGION;
+
+  await setE2EEnvVarsFromSsm();
+  await grantRedshiftAccess(getE2ETestEnv('REDSHIFT_WORKGROUP_NAME'));
+
+  const eventNamesEnv = process.env.EVENT_ONBOARDING_EVENT_NAMES;
+  if (!eventNamesEnv) {
+    throw new Error('EVENT_ONBOARDING_EVENT_NAMES env var is required for check-only mode.');
+  }
+
+  (global as { checkOnlyEventNames?: string[] }).checkOnlyEventNames = eventNamesEnv.split(',').map(v => v.trim());
+}

--- a/tests/e2e-tests/setup-event-onboarding.ts
+++ b/tests/e2e-tests/setup-event-onboarding.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+import { AWS_REGION, STACK_NAME } from '../shared-test-code/constants';
+import { addMessageToQueue } from '../shared-test-code/aws/sqs/add-message-to-queue';
+import { executeStepFunction } from '../shared-test-code/aws/step-function/execute-step-function';
+import { pollForRawLayerData, pollForStageLayerData } from '../shared-test-code/poll-for-athena-data';
+import { pollForFactJourneyData } from '../shared-test-code/poll-for-redshift-data';
+import { grantRedshiftAccess } from '../shared-test-code/aws/redshift/grant-access';
+import { setE2EEnvVarsFromSsm } from './helpers/config/ssm-config';
+import { constructTestEvent } from './test-events/event-onboarding-test-event';
+import { eventOnboardingTestEvents } from './config/event-onboarding.config';
+import { getE2ETestEnv } from './helpers/utils/utils';
+import { AuditEvent } from '../../common/types/event';
+
+export default async function globalSetup() {
+  const setupStartTime = Date.now();
+
+  try {
+    process.env.STACK_NAME = process.env.STACK_NAME ?? STACK_NAME;
+    process.env.AWS_REGION = process.env.AWS_REGION ?? AWS_REGION;
+
+    await setE2EEnvVarsFromSsm();
+    await grantRedshiftAccess(getE2ETestEnv('REDSHIFT_WORKGROUP_NAME'));
+
+    const queueUrl = getE2ETestEnv('DAP_E2E_TEST_PRODUCER_QUEUE_URL');
+
+    const now = new Date();
+    const expectedDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+    const sentEvents: { event_id: string; eventConfig: (typeof eventOnboardingTestEvents)[number] }[] = [];
+    const allEvents: AuditEvent[] = [];
+
+    for (const eventConfig of eventOnboardingTestEvents) {
+      const event = constructTestEvent(eventConfig);
+      await addMessageToQueue(event, queueUrl);
+      allEvents.push(event);
+      sentEvents.push({ event_id: event.event_id, eventConfig });
+      console.log(`📤 Sent event:`, JSON.stringify(event, null, 2));
+    }
+
+    const eventIds = allEvents.map(e => e.event_id);
+
+    console.log(
+      '⏳ Waiting 10 mins before polling (event-processing transit + DAP batching can take up to 15 mins)...',
+    );
+    const rawPollStart = Date.now();
+    await new Promise(resolve => setTimeout(resolve, 10 * 60 * 1000));
+
+    console.log('⏳ Now polling for events in raw layer (up to 15 mins)...');
+    await pollForRawLayerData(eventIds, { maxWaitTimeMs: 15 * 60 * 1000, pollIntervalMs: 10000 });
+    console.log(`✅ Events found in raw layer after ${Math.round((Date.now() - rawPollStart) / 1000)}s`);
+
+    const rawToStageStepFunction = getE2ETestEnv('RAW_TO_STAGE_STEP_FUNCTION');
+    await executeStepFunction(rawToStageStepFunction, undefined, 'event-onboarding-e2e', 25 * 60 * 1000);
+    await pollForStageLayerData(eventIds, { maxWaitTimeMs: 10 * 60 * 1000, pollIntervalMs: 10000 });
+    await pollForFactJourneyData(eventIds, { maxWaitTimeMs: 5 * 60 * 1000, pollIntervalMs: 5000 });
+
+    // Store data globally for tests
+    (global as { sentEvents?: typeof sentEvents }).sentEvents = sentEvents;
+    (global as { expectedDate?: string }).expectedDate = expectedDate;
+
+    console.log(
+      `\n📋 Event IDs for check-only mode:\n   EVENT_ONBOARDING_EVENT_IDS=${sentEvents.map(e => e.event_id).join(',')}\n`,
+    );
+
+    const totalSetupDuration = Date.now() - setupStartTime;
+    console.log(`🎉 Event Onboarding e2e setup completed in ${Math.round(totalSetupDuration / 1000)}s`);
+  } catch (error) {
+    const setupDuration = Date.now() - setupStartTime;
+    console.error(`❌ Event Onboarding e2e setup failed after ${Math.round(setupDuration / 1000)}s:`, error);
+    throw error;
+  }
+}

--- a/tests/e2e-tests/test-events/event-onboarding-test-event.ts
+++ b/tests/e2e-tests/test-events/event-onboarding-test-event.ts
@@ -1,0 +1,13 @@
+import { AuditEvent } from '../../../common/types/event';
+import { randomUUID } from 'node:crypto';
+import { EventOnboardingTestEvent } from '../config/event-onboarding.config';
+
+export const constructTestEvent = (event: EventOnboardingTestEvent): AuditEvent => {
+  const now = Date.now();
+  return {
+    ...event,
+    event_id: randomUUID(),
+    timestamp: Math.floor(now / 1000),
+    event_timestamp_ms: now,
+  } as unknown as AuditEvent;
+};

--- a/tests/e2e-tests/test-suites/event-onboarding-check-only/event-onboarding-check-only.spec.ts
+++ b/tests/e2e-tests/test-suites/event-onboarding-check-only/event-onboarding-check-only.spec.ts
@@ -1,0 +1,13 @@
+import { queryConformLayerByEventName, printConformCheckOnly } from '../../helpers/utils/conform-layer-results';
+
+const getEventNames = (): string[] => (global as { checkOnlyEventNames?: string[] }).checkOnlyEventNames || [];
+
+describe('Event Onboarding E2E Tests (check only)', () => {
+  for (const eventName of getEventNames()) {
+    it(`should find conform layer data for ${eventName}`, async () => {
+      const result = await queryConformLayerByEventName(eventName);
+      printConformCheckOnly(eventName, result);
+      expect(result.row).toBeDefined();
+    }, 30000);
+  }
+});

--- a/tests/e2e-tests/test-suites/event-onboarding/event-onboarding.spec.ts
+++ b/tests/e2e-tests/test-suites/event-onboarding/event-onboarding.spec.ts
@@ -1,0 +1,24 @@
+import { eventOnboardingTestEvents } from '../../config/event-onboarding.config';
+import { deriveExpected } from '../../helpers/utils/derive-expected';
+import { queryConformLayer, printConformResults } from '../../helpers/utils/conform-layer-results';
+
+interface SentEvent {
+  event_id: string;
+  eventConfig: (typeof eventOnboardingTestEvents)[number];
+}
+
+const getSentEvents = (): SentEvent[] => (global as { sentEvents?: SentEvent[] }).sentEvents || [];
+
+describe('Event Onboarding E2E Tests', () => {
+  for (const { event_id, eventConfig } of getSentEvents()) {
+    const expected = deriveExpected(eventConfig, event_id, (global as { expectedDate?: string }).expectedDate || '');
+
+    it(`${eventConfig.event_name} (${event_id})`, async () => {
+      const result = await queryConformLayer(event_id);
+      expect(result.row).toBeDefined();
+
+      const mismatches = printConformResults(String(eventConfig.event_name), event_id, expected, result);
+      expect(mismatches).toHaveLength(0);
+    }, 30000);
+  }
+});


### PR DESCRIPTION
### Description
Adds Event Onboarding E2E tests, mirroring the existing RP Onboarding pattern. There are two modes:

- Full run (npm run test:e2e:event-onboarding) — sends configured event payloads through the pipeline, waits for them to land in the conform layer, and asserts that core fields match expected values.

- Check only (EVENT_ONBOARDING_EVENT_NAMES=EVCS_IDENTITY_REPLACED npm run test:e2e:event-onboarding:check-only) — queries the conform layer for the most recent row matching each event name and prints it with extensions. Useful for quick verification without running the full 25-minute pipeline.

### Changes

- Added event onboarding test config, setup, specs, and jest configs for both full run and check-only modes

- Added shared helpers for querying the conform layer and printing results (by event ID for the full run, by event name for check-only)

- Added `test:e2e:event-onboarding` and `test:e2e:event-onboarding:check-only` npm scripts

- Updated README with Event Onboarding documentation

### Testing
`test:e2e:event-onboarding`

<img width="920" height="688" alt="Screenshot 2026-04-09 at 16 59 09" src="https://github.com/user-attachments/assets/f2fa3af5-fba8-4675-80a7-730ce9890167" />

`EVENT_ONBOARDING_EVENT_NAMES=EVCS_IDENTITY_REPLACED
npm run test:e2e:event-onboarding:check-only`

<img width="920" height="405" alt="Screenshot 2026-04-09 at 16 28 24" src="https://github.com/user-attachments/assets/4793b419-51a7-461c-805e-2eacc8612b66" />