### PR TITLE
Add E2ETestObfuscationHmacSecretArnParameter

### DIFF
--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -240,7 +240,7 @@ E2ETestObfuscationHmacSecretArnParameter:
   Properties:
     Name: !Sub /tests/${AWS::StackName}/obfuscationHmacSecretArn
     Type: String
-    Value: event-processing-self/ObfuscationHmac/dapPreview
+    Value: dap/e2e/ObfuscationHmacKey
 
 E2ETestProducerQueueArnParameter:
   Type: AWS::SSM::Parameter

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -234,6 +234,14 @@ E2ETestProducerQueueUrlParameter:
     Type: String
     Value: !Ref E2ETestProducerQueue
 
+E2ETestObfuscationHmacSecretArnParameter:
+  Type: AWS::SSM::Parameter
+  Condition: IsStaging
+  Properties:
+    Name: !Sub /tests/${AWS::StackName}/obfuscationHmacSecretArn
+    Type: String
+    Value: event-processing-self/ObfuscationHmac/dapPreview
+
 E2ETestProducerQueueArnParameter:
   Type: AWS::SSM::Parameter
   Condition: IsStaging


### PR DESCRIPTION
I've added the self serve secret to the DAP secrets manager in staging env
This is to add E2ETestObfuscationHmacSecretArnParameter to parameter store in DAP staging env