### PR TITLE
e2e regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ There are two types of BAU E2E tests:
 * **RP Onboarding** — verifies that a new relying party's events are correctly reflected in the conform layer dim and ref tables
 * **Event Onboarding** — verifies that a new event type is processed and lands in the conform layer dim and fact journey tables correctly
 
+There is also an E2E regression test:
+* **Regression** — verifies the full pipeline end-to-end for an existing event type, including user_id hashing and extension processing. This is not currently in the CI/CD pipeline and is intended to be run manually as and when needed
+
 
 ###### RP Onboarding
 
@@ -254,6 +257,32 @@ EVENT_ONBOARDING_EVENT_NAMES=EVCS_IDENTITY_REPLACED npm run test:e2e:event-onboa
 ```
 
 The check-only command prints the most recent conform layer row for each event name, including extensions.
+
+###### Regression
+
+The E2E regression test verifies the full data pipeline end-to-end for an existing event type. It sends a raw event through the pipeline and asserts that all fields land correctly in the Redshift conform layer, including fields that are transformed by the pipeline such as `user_id` (HMAC-hashed), `channel_name` (derived), and extensions (keys lowercased). Fields that pass through unchanged (`event_id`, `component_id`, `event_name`, `user_govuk_signin_journey_id`, `date`, `client_id`, `event_timestamp_ms`) are asserted directly from the input event.
+
+This test is **not currently in the CI/CD pipeline** due to the time taken by Firehose delivery and the Step Function execution in the staging environment. It is intended to be run manually as and when needed.
+
+Prerequisites:
+* Set up ~/.aws/config file with the correct AWS credentials
+* Login to AWS:
+  ```sh
+  export AWS_PROFILE=data-dap-staging
+  aws sso login
+  ```
+
+Test configuration is in [tests/e2e-tests/config/e2e-regression.config.ts](tests/e2e-tests/config/e2e-regression.config.ts). The config contains a single event payload and an `expected` block defining the values that are transformed or derived by the pipeline. `event_id`, `timestamp` and `event_timestamp_ms` are generated automatically at send time.
+
+To run the test:
+
+```sh
+# Full run — sends event to SQS, waits for Firehose delivery and raw layer arrival, executes the step function, then checks the conform layer
+# Takes ~30 minutes due to Firehose delivery, event processing and ETL execution
+npm run test:e2e:regression
+```
+
+The test output includes a comparison table showing expected vs actual values for all asserted fields, with mismatched columns highlighted in red.
 
 #### Test reports
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "test:e2e:rp-onboarding": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.rp-onboarding.ts --runInBand",
     "test:e2e:rp-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.rp-onboarding-check-only.ts --runInBand",
     "test:e2e:event-onboarding": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.event-onboarding.ts --runInBand",
-    "test:e2e:event-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.event-onboarding-check-only.ts --runInBand"
+    "test:e2e:event-onboarding:check-only": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.event-onboarding-check-only.ts --runInBand",
+    "test:e2e:regression": "NODE_OPTIONS='--experimental-vm-modules' jest -c ./tests/e2e-tests/jest.config.e2e-regression.ts --runInBand"
   },
   "lint-staged": {
     "*": "prettier --write",

--- a/tests/e2e-tests/config/e2e-regression.config.ts
+++ b/tests/e2e-tests/config/e2e-regression.config.ts
@@ -1,0 +1,52 @@
+/**
+ * E2E Regression Test Configuration
+ *
+ * This test sends a raw event through the full pipeline and verifies it lands
+ * correctly in the conform layer. event_id, timestamp and event_timestamp_ms
+ * are generated automatically at send time.
+ *
+ * The `expected` block defines values that are transformed or derived by the
+ * pipeline (e.g. channel_name is derived, extension keys are lowercased).
+ * Fields that pass through unchanged (event_name, component_id, etc.) are
+ * asserted directly from the input event.
+ */
+
+import { AuditEvent } from '../../../common/types/event';
+
+export interface ExpectedConformValues {
+  channel_name: string;
+  client_id: string;
+  extensions: { parent_attribute_name: string; event_attribute_name: string; event_attribute_value: string }[];
+}
+
+export interface RegressionTestConfig {
+  event: Omit<AuditEvent, 'event_id' | 'timestamp'>;
+  expected: ExpectedConformValues;
+}
+
+export const regressionTestConfig: RegressionTestConfig = {
+  event: {
+    event_name: 'DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED',
+    client_id: 'sXr5F6w5QytPPJN-Dtsgbl6hegQ',
+    component_id: 'https://review-b-async.staging.account.gov.uk',
+    user: {
+      govuk_signin_journey_id: 'e2e-regression-journey-id',
+      session_id: 'e2e-regression-session-id',
+      user_id: 'urn:uuid:e2e-regression-user-id',
+    },
+    extensions: {
+      documentType: 'NFC_PASSPORT',
+    },
+  },
+  expected: {
+    channel_name: 'App',
+    client_id: 'sXr5F6w5QytPPJN-Dtsgbl6hegQ',
+    extensions: [
+      {
+        parent_attribute_name: 'extensions',
+        event_attribute_name: 'documenttype',
+        event_attribute_value: 'NFC_PASSPORT',
+      },
+    ],
+  },
+};

--- a/tests/e2e-tests/helpers/config/ssm-config.ts
+++ b/tests/e2e-tests/helpers/config/ssm-config.ts
@@ -7,6 +7,7 @@ import {
 const e2eSsmMappings = {
   ...sharedSsmMappings,
   DAP_E2E_TEST_PRODUCER_QUEUE_URL: formatTestStackSsmParam('dapE2ETestProducerQueueUrl'),
+  OBFUSCATION_HMAC_SECRET_ARN: formatTestStackSsmParam('obfuscationHmacSecretArn'),
 };
 
 export const setE2EEnvVarsFromSsm = async () => setEnvVarsFromSsm(e2eSsmMappings);

--- a/tests/e2e-tests/helpers/utils/conform-layer-results.ts
+++ b/tests/e2e-tests/helpers/utils/conform-layer-results.ts
@@ -1,11 +1,13 @@
-/* eslint-disable no-console */
 import { executeRedshiftQuery } from '../../../shared-test-code/aws/redshift/execute-redshift-query';
 import { ExpectedConformData } from './derive-expected';
 
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-interface ConformResult {
+const write = (text: string) => process.stdout.write(text + '\n');
+
+export interface ConformResult {
   row: Record<string, string | number> | undefined;
   extensions: Record<string, string | number>[];
 }
@@ -17,13 +19,16 @@ const CONFORM_BASE_QUERY = `SELECT
          duj.user_govuk_signin_journey_id,
          dd.date,
          du.user_id,
-         djc.channel_name
+         djc.channel_name,
+         drp.client_id,
+         f.event_timestamp_ms
        FROM conformed_refactored.fact_user_journey_event_refactored f
        LEFT JOIN conformed_refactored.dim_event_refactored de ON f.event_key = de.event_key
        LEFT JOIN conformed_refactored.dim_user_journey_event_refactored duj ON f.user_journey_key = duj.user_journey_key
        LEFT JOIN conformed_refactored.dim_date_refactored dd ON f.date_key = dd.date_key
        LEFT JOIN conformed_refactored.dim_user_refactored du ON f.user_key = du.user_key
-       LEFT JOIN conformed_refactored.dim_journey_channel_refactored djc ON f.journey_channel_key = djc.journey_channel_key`;
+       LEFT JOIN conformed_refactored.dim_journey_channel_refactored djc ON f.journey_channel_key = djc.journey_channel_key
+       LEFT JOIN conformed_refactored.dim_relying_party_refactored drp ON f.relying_party_key = drp.relying_party_key`;
 
 const queryExtensions = async (eventId: string) =>
   executeRedshiftQuery(
@@ -58,66 +63,157 @@ export const printConformResults = (
   const { row, extensions } = result;
   const mismatches: string[] = [];
 
-  const columns = ['event_id', 'component_id', 'event_name', 'journey_id', 'date'] as const;
-  const expectedRow = [
-    expected.event_id,
-    expected.component_id,
-    expected.event_name,
-    expected.user_govuk_signin_journey_id,
-    expected.date,
-  ];
-  const actualRow = [
-    String(row?.event_id ?? ''),
-    String(row?.component_id ?? ''),
-    String(row?.event_name ?? ''),
-    String(row?.user_govuk_signin_journey_id || ''),
-    String(row?.date ?? ''),
+  const lines: string[] = [`\n📋 ${eventName} (${eventId})`];
+
+  const fields: { label: string; expected: string; actual: string }[] = [
+    { label: 'event_id', expected: expected.event_id, actual: String(row?.event_id ?? '') },
+    { label: 'component_id', expected: expected.component_id, actual: String(row?.component_id ?? '') },
+    { label: 'event_name', expected: expected.event_name, actual: String(row?.event_name ?? '') },
+    {
+      label: 'journey_id',
+      expected: expected.user_govuk_signin_journey_id,
+      actual: String(row?.user_govuk_signin_journey_id || ''),
+    },
+    { label: 'date', expected: expected.date, actual: String(row?.date ?? '') },
   ];
 
-  const widths = columns.map((col, i) => Math.max(col.length, expectedRow[i].length, actualRow[i].length));
-
-  const label = '          ';
-  const separator = '─'.repeat(label.length) + '┼' + widths.map(w => '─'.repeat(w + 2)).join('┼');
-  const header = label + '│' + columns.map((col, i) => ` ${col.padEnd(widths[i])} `).join('│');
-
-  const expectedLine =
-    'Expected'.padEnd(label.length) + '│' + expectedRow.map((v, i) => ` ${v.padEnd(widths[i])} `).join('│');
-
-  const actualCells = actualRow.map((v, i) => {
-    const match = v === expectedRow[i];
-    if (!match) mismatches.push(columns[i]);
-    const padded = ` ${v.padEnd(widths[i])} `;
-    return match ? green(padded) : red(padded);
+  const labelWidth = Math.max(...fields.map(f => f.label.length), 'channel_name'.length);
+  lines.push('');
+  fields.forEach(({ label, expected: exp, actual }) => {
+    const match = exp === actual;
+    if (!match) mismatches.push(label);
+    if (match) {
+      lines.push(`  ${label.padEnd(labelWidth)}  ${green(actual)}  ✅`);
+    } else {
+      lines.push(`  ${label.padEnd(labelWidth)}  ${red(actual)}  ❌`);
+      lines.push(`  ${''.padEnd(labelWidth)}  ${dim(`expected: ${exp}`)}`);
+    }
   });
-  const allMatch = mismatches.length === 0;
-  const actualLine = 'Actual'.padEnd(label.length) + '│' + actualCells.join('│') + `  ${allMatch ? '✅' : '❌'}`;
 
-  const lines = [
-    `\n📋 ${eventName} (${eventId})`,
-    `  ${header}`,
-    `  ${separator}`,
-    `  ${expectedLine}`,
-    `  ${actualLine}`,
-  ];
+  lines.push('');
+  lines.push(`  ${'channel_name'.padEnd(labelWidth)}  ${row?.channel_name ?? '(not found)'}`);
 
   if (mismatches.length > 0) {
     lines.push(`\n  ⚠️  Mismatched: ${mismatches.join(', ')}`);
   }
 
-  lines.push('');
-  lines.push(`  user_id: ${row?.user_id ?? '(not found)'} (hashed)`);
-  lines.push(`  channel_name: ${row?.channel_name ?? '(not found)'}`);
-
+  lines.push(`\n  ${dim('Extensions')}`);
   if (extensions.length === 0) {
-    lines.push('  extensions: none');
+    lines.push('  none');
   } else {
-    extensions.forEach((ext, i) => {
-      const prefix = i === 0 ? '  extensions: ' : '              ';
-      lines.push(`${prefix}${ext.parent_attribute_name}.${ext.event_attribute_name} = "${ext.event_attribute_value}"`);
+    extensions.forEach(ext => {
+      lines.push(`  ${ext.parent_attribute_name}.${ext.event_attribute_name} = "${ext.event_attribute_value}"`);
     });
   }
 
-  console.log(lines.join('\n'));
+  lines.push('');
+  write(lines.join('\n'));
+  return mismatches;
+};
+
+export interface ExpectedConformDataFull extends ExpectedConformData {
+  user_id: string;
+  channel_name: string;
+  client_id: string;
+  event_timestamp_ms: string;
+  extensions: { parent_attribute_name: string; event_attribute_name: string; event_attribute_value: string }[];
+}
+
+export const printConformResultsFull = (
+  eventName: string,
+  eventId: string,
+  expected: ExpectedConformDataFull,
+  result: ConformResult,
+  timing?: { setupDurationMs: number; testDurationMs: number },
+): string[] => {
+  const { row, extensions } = result;
+  const mismatches: string[] = [];
+
+  const lines: string[] = [`\n📋 ${eventName} (${eventId})`];
+
+  // Vertical key/value fields
+  const fields: { label: string; expected: string; actual: string }[] = [
+    { label: 'event_id', expected: expected.event_id, actual: String(row?.event_id ?? '') },
+    { label: 'component_id', expected: expected.component_id, actual: String(row?.component_id ?? '') },
+    { label: 'event_name', expected: expected.event_name, actual: String(row?.event_name ?? '') },
+    {
+      label: 'journey_id',
+      expected: expected.user_govuk_signin_journey_id,
+      actual: String(row?.user_govuk_signin_journey_id || ''),
+    },
+    { label: 'date', expected: expected.date, actual: String(row?.date ?? '') },
+    { label: 'user_id', expected: expected.user_id, actual: String(row?.user_id ?? '') },
+    { label: 'channel_name', expected: expected.channel_name, actual: String(row?.channel_name ?? '') },
+    { label: 'client_id', expected: expected.client_id, actual: String(row?.client_id ?? '') },
+    {
+      label: 'event_timestamp_ms',
+      expected: expected.event_timestamp_ms,
+      actual: String(row?.event_timestamp_ms ?? ''),
+    },
+  ];
+
+  const labelWidth = Math.max(...fields.map(f => f.label.length));
+  lines.push('');
+  fields.forEach(({ label, expected: exp, actual }) => {
+    const match = exp === actual;
+    if (!match) mismatches.push(label);
+    if (match) {
+      lines.push(`  ${label.padEnd(labelWidth)}  ${green(actual)}  ✅`);
+    } else {
+      lines.push(`  ${label.padEnd(labelWidth)}  ${red(actual)}  ❌`);
+      lines.push(`  ${''.padEnd(labelWidth)}  ${dim(`expected: ${exp}`)}`);
+    }
+  });
+
+  // Extensions table
+  const formatExt = (ext: Record<string, string | number>) =>
+    `${ext.parent_attribute_name}.${ext.event_attribute_name} = "${ext.event_attribute_value}"`;
+  const expectedExts = expected.extensions.map(formatExt);
+  const actualExts = extensions.map(formatExt);
+
+  lines.push(`\n  ${dim('Extensions')}`);
+  if (expectedExts.length === 0 && actualExts.length === 0) {
+    lines.push('  none');
+  } else {
+    const allExtKeys = Array.from(new Set([...expectedExts, ...actualExts]));
+    allExtKeys.forEach(ext => {
+      const inExpected = expectedExts.includes(ext);
+      const inActual = actualExts.includes(ext);
+      let status: string;
+      if (inExpected && inActual) {
+        status = '✅';
+      } else if (inExpected && !inActual) {
+        status = red('❌ missing');
+        mismatches.push(`missing extension: ${ext}`);
+      } else {
+        status = dim('(extra)');
+      }
+      lines.push(`  ${ext}  ${status}`);
+    });
+  }
+
+  const hasConfigVersion = extensions.some(
+    ext => String(ext.parent_attribute_name) === 'txma' && String(ext.event_attribute_name) === 'configversion',
+  );
+  if (!hasConfigVersion) {
+    mismatches.push('txma.configversion is missing');
+    lines.push(`\n  ${red('⚠️  txma.configversion is missing')}`);
+  }
+
+  if (mismatches.length > 0) {
+    lines.push(`\n  ⚠️  Mismatched: ${mismatches.join(', ')}`);
+  }
+
+  // Timing summary
+  if (timing) {
+    const setupSecs = Math.round(timing.setupDurationMs / 1000);
+    const testSecs = (timing.testDurationMs / 1000).toFixed(1);
+    const totalSecs = Math.round((timing.setupDurationMs + timing.testDurationMs) / 1000);
+    lines.push(`\n  ⏱️  Setup: ${setupSecs}s │ Test: ${testSecs}s │ Total: ${totalSecs}s`);
+  }
+
+  lines.push('');
+  write(lines.join('\n'));
   return mismatches;
 };
 
@@ -151,5 +247,5 @@ export const printConformCheckOnly = (eventName: string, result: ConformResult) 
     });
   }
 
-  console.log(lines.join('\n'));
+  write(lines.join('\n'));
 };

--- a/tests/e2e-tests/helpers/utils/print-results.ts
+++ b/tests/e2e-tests/helpers/utils/print-results.ts
@@ -1,7 +1,7 @@
-/* eslint-disable no-console */
-
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+
+const write = (text: string) => process.stdout.write(text + '\n');
 
 export const printResults = (
   tableName: string,
@@ -54,5 +54,5 @@ export const printResults = (
   }
 
   lines.push('');
-  console.log(lines.join('\n'));
+  write(lines.join('\n'));
 };

--- a/tests/e2e-tests/jest.config.e2e-regression.ts
+++ b/tests/e2e-tests/jest.config.e2e-regression.ts
@@ -1,0 +1,23 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest',
+  verbose: true,
+  testMatch: ['**/tests/e2e-tests/test-suites/e2e-regression/**/*.spec.ts'],
+  globalSetup: '<rootDir>/setup-e2e-regression.ts',
+  testTimeout: 600000,
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        suiteName: 'E2E Regression tests',
+        outputDirectory: '<rootDir>/reports',
+        ancestorSeparator: ',',
+        includeConsoleOutput: true,
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/tests/e2e-tests/setup-e2e-regression.ts
+++ b/tests/e2e-tests/setup-e2e-regression.ts
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import { AWS_REGION, STACK_NAME } from '../shared-test-code/constants';
+import { addMessageToQueue } from '../shared-test-code/aws/sqs/add-message-to-queue';
+import { executeStepFunction } from '../shared-test-code/aws/step-function/execute-step-function';
+import { pollForRawLayerData, pollForStageLayerData } from '../shared-test-code/poll-for-athena-data';
+import { pollForFactJourneyData } from '../shared-test-code/poll-for-redshift-data';
+import { grantRedshiftAccess } from '../shared-test-code/aws/redshift/grant-access';
+import { setE2EEnvVarsFromSsm } from './helpers/config/ssm-config';
+import { getE2ETestEnv } from './helpers/utils/utils';
+import { regressionTestConfig } from './config/e2e-regression.config';
+import { AuditEvent } from '../../common/types/event';
+import { randomUUID } from 'node:crypto';
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+
+export default async function globalSetup() {
+  const setupStartTime = Date.now();
+
+  try {
+    process.env.STACK_NAME = process.env.STACK_NAME ?? STACK_NAME;
+    process.env.AWS_REGION = process.env.AWS_REGION ?? AWS_REGION;
+
+    await setE2EEnvVarsFromSsm();
+    await grantRedshiftAccess(getE2ETestEnv('REDSHIFT_WORKGROUP_NAME'));
+
+    const queueUrl = getE2ETestEnv('DAP_E2E_TEST_PRODUCER_QUEUE_URL');
+    const hmacSecretArn = getE2ETestEnv('OBFUSCATION_HMAC_SECRET_ARN');
+
+    const secretsManager = new SecretsManagerClient({ region: AWS_REGION });
+    const secret = await secretsManager.send(new GetSecretValueCommand({ SecretId: hmacSecretArn }));
+    const hmacKey = secret.SecretString;
+    console.log('🔑 Retrieved obfuscation HMAC key from Secrets Manager');
+
+    const now = new Date();
+    const eventId = randomUUID();
+    const timestamp = Math.floor(now.getTime() / 1000);
+    const expectedDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+    const event = {
+      ...regressionTestConfig.event,
+      event_id: eventId,
+      timestamp,
+      event_timestamp_ms: now.getTime(),
+    } as unknown as AuditEvent;
+
+    await addMessageToQueue(event, queueUrl);
+    console.log(`📤 Sent event:`, JSON.stringify(event, null, 2));
+
+    console.log('⏳ Waiting 10 mins before polling...');
+    const rawPollStart = Date.now();
+    await new Promise(resolve => setTimeout(resolve, 10 * 60 * 1000));
+
+    console.log('⏳ Polling for event in raw layer (up to 15 mins)...');
+    await pollForRawLayerData([eventId], { maxWaitTimeMs: 15 * 60 * 1000, pollIntervalMs: 10000 });
+    console.log(`✅ Event found in raw layer after ${Math.round((Date.now() - rawPollStart) / 1000)}s`);
+
+    const rawToStageStepFunction = getE2ETestEnv('RAW_TO_STAGE_STEP_FUNCTION');
+    await executeStepFunction(rawToStageStepFunction, undefined, 'e2e-regression', 25 * 60 * 1000);
+    await pollForStageLayerData([eventId], { maxWaitTimeMs: 10 * 60 * 1000, pollIntervalMs: 10000 });
+    await pollForFactJourneyData([eventId], { maxWaitTimeMs: 5 * 60 * 1000, pollIntervalMs: 5000 });
+
+    (global as { regressionEventId?: string }).regressionEventId = eventId;
+    (global as { regressionExpectedDate?: string }).regressionExpectedDate = expectedDate;
+    (global as { regressionHmacKey?: string }).regressionHmacKey = hmacKey;
+    (global as { regressionEventTimestampMs?: number }).regressionEventTimestampMs = now.getTime();
+
+    const totalSetupDuration = Date.now() - setupStartTime;
+    (global as { regressionSetupDurationMs?: number }).regressionSetupDurationMs = totalSetupDuration;
+    console.log(`🎉 E2E regression setup completed in ${Math.round(totalSetupDuration / 1000)}s`);
+  } catch (error) {
+    const setupDuration = Date.now() - setupStartTime;
+    console.error(`❌ E2E regression setup failed after ${Math.round(setupDuration / 1000)}s:`, error);
+    throw error;
+  }
+}

--- a/tests/e2e-tests/test-suites/e2e-regression/e2e-regression.spec.ts
+++ b/tests/e2e-tests/test-suites/e2e-regression/e2e-regression.spec.ts
@@ -1,0 +1,44 @@
+import { createHmac } from 'node:crypto';
+import { queryConformLayer, printConformResultsFull } from '../../helpers/utils/conform-layer-results';
+import { regressionTestConfig } from '../../config/e2e-regression.config';
+
+const getEventId = (): string => (global as { regressionEventId?: string }).regressionEventId || '';
+const getExpectedDate = (): string => (global as { regressionExpectedDate?: string }).regressionExpectedDate || '';
+const getHmacKey = (): string => (global as { regressionHmacKey?: string }).regressionHmacKey || '';
+const getSetupDuration = (): number =>
+  (global as { regressionSetupDurationMs?: number }).regressionSetupDurationMs || 0;
+const getEventTimestampMs = (): number =>
+  (global as { regressionEventTimestampMs?: number }).regressionEventTimestampMs || 0;
+
+const { event, expected } = regressionTestConfig;
+const user = event.user as { user_id: string; govuk_signin_journey_id: string };
+
+describe('E2E Regression Tests', () => {
+  it(`${event.event_name}`, async () => {
+    const testStart = Date.now();
+    const eventId = getEventId();
+    const result = await queryConformLayer(eventId);
+    expect(result.row).toBeDefined();
+
+    const expectedConform = {
+      event_id: eventId,
+      component_id: String(event.component_id),
+      event_name: String(event.event_name),
+      user_govuk_signin_journey_id: user.govuk_signin_journey_id,
+      date: getExpectedDate(),
+      user_id: createHmac('sha256', getHmacKey()).update(user.user_id).digest('hex'),
+      channel_name: expected.channel_name,
+      client_id: expected.client_id,
+      event_timestamp_ms: String(getEventTimestampMs()),
+      extensions: expected.extensions,
+    };
+
+    const mismatches = printConformResultsFull(String(event.event_name), eventId, expectedConform, result, {
+      setupDurationMs: getSetupDuration(),
+      testDurationMs: Date.now() - testStart,
+    });
+    if (mismatches.length > 0) {
+      throw new Error(`Mismatched fields: ${mismatches.join(', ')}`);
+    }
+  }, 30000);
+});

--- a/tests/e2e-tests/test-suites/event-onboarding/event-onboarding.spec.ts
+++ b/tests/e2e-tests/test-suites/event-onboarding/event-onboarding.spec.ts
@@ -18,7 +18,9 @@ describe('Event Onboarding E2E Tests', () => {
       expect(result.row).toBeDefined();
 
       const mismatches = printConformResults(String(eventConfig.event_name), event_id, expected, result);
-      expect(mismatches).toHaveLength(0);
+      if (mismatches.length > 0) {
+        throw new Error(`Mismatched fields: ${mismatches.join(', ')}`);
+      }
     }, 30000);
   }
 });

--- a/tests/e2e-tests/types/e2e-test-env.ts
+++ b/tests/e2e-tests/types/e2e-test-env.ts
@@ -1,3 +1,3 @@
 import { SharedTestEnvName } from '../../shared-test-code/types/test-env';
 
-export type E2ETestEnvName = SharedTestEnvName | 'DAP_E2E_TEST_PRODUCER_QUEUE_URL';
+export type E2ETestEnvName = SharedTestEnvName | 'DAP_E2E_TEST_PRODUCER_QUEUE_URL' | 'OBFUSCATION_HMAC_SECRET_ARN';


### PR DESCRIPTION
- Added manual E2E regression test (npm run test:e2e:regression) that verifies the full staging pipeline end-to-end for an existing event type, including transformed fields (user_id HMAC hash, channel_name, extensions)

- Improved event onboarding test to include mismatched field names in the error message

- Changed event onboarding and regression test output to a vertical key/value format for readability

- Replaced console.log with process.stdout.write in test output helpers to fix eslint warnings

- Updated README with e2e regression test documentation

To run:
```
export AWS_PROFILE=data-dap-staging
aws sso login
```
`npm run test:e2e:regression`


<img width="921" height="511" alt="Screenshot 2026-04-21 at 17 29 18" src="https://github.com/user-attachments/assets/cf032a36-70d7-4a8f-b070-1327ae607697" />

Unsuccessful run should show the mismatch like this (for example):
<img width="1015" height="750" alt="Screenshot 2026-04-21 at 16 59 44" src="https://github.com/user-attachments/assets/a046f118-f670-4860-9533-10a3c2e8564d" />

