### PR TITLE
DPT-2768: Resolve deprecated globals issue

### DIFF
--- a/tests/integration-tests/vitest.config.unified.ts
+++ b/tests/integration-tests/vitest.config.unified.ts
@@ -8,12 +8,6 @@ export default defineConfig({
     globalSetup: './tests/integration-tests/setup-main-test-suite.ts',
     teardownTimeout: 600000,
     testTimeout: 600000,
-    pool: 'forks',
-    poolOptions: {
-      forks: {
-        maxForks: 6,
-      },
-    },
     reporters: [
       'verbose',
       [
@@ -28,22 +22,26 @@ export default defineConfig({
       {
         test: {
           name: 'main-test-suite',
+          globals: true,
+          environment: 'node',
           include: ['tests/integration-tests/test-suites/**/*.spec.ts'],
           exclude: ['tests/integration-tests/test-suites/raw-to-stage-unhappy-path/**'],
           globalSetup: './tests/integration-tests/setup-main-test-suite.ts',
           testTimeout: 600000,
           pool: 'forks',
-          poolOptions: { forks: { maxForks: 6 } },
+          maxForks: 6,
         },
       },
       {
         test: {
           name: 'raw-to-stage-unhappy-path',
+          globals: true,
+          environment: 'node',
           include: ['tests/integration-tests/test-suites/raw-to-stage-unhappy-path/**/*.spec.ts'],
           globalSetup: './tests/integration-tests/setup-raw-to-stage-unhappy-path.ts',
           testTimeout: 600000,
           pool: 'forks',
-          poolOptions: { forks: { singleFork: true } },
+          singleFork: true,
         },
       },
     ],


### PR DESCRIPTION
Fix: Resolve describe is not defined errors in integration tests (Vitest 4 migration)

In Vitest 4, the top-level test config is no longer inherited by workspace projects. This meant globals: true was not applied to each project, causing describe, it, expect etc. to be undefined at runtime across all 9 integration test suites.

Changes to vitest.config.unified.ts:

- Added globals: true and environment: 'node' explicitly to each project config (main-test-suite and raw-to-stage-unhappy-path)
- Replaced deprecated poolOptions: { forks: { maxForks, singleFork } } with the Vitest 4 flat options (maxForks, singleFork at the project level)
- Removed top-level pool/poolOptions which no longer apply when using projects