### PR TITLE
DPT-2768: Fix failing Lambdas

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -18,7 +18,7 @@ const handlerDirs = readdirSync(srcDir, { withFileTypes: true })
 await Promise.all(
   handlerDirs.map(lambdaName => {
     const entryPoint = join(srcDir, lambdaName, 'handler.ts');
-    const outfile = join(distDir, `${lambdaName}.js`);
+    const outfile = join(distDir, `${lambdaName}.mjs`);
 
     console.log(`Building handlers/${lambdaName}`);
     return build({


### PR DESCRIPTION
Fixing Lambdas failures

Lambda handlers were built with format: 'esm' but output as .js. The Node.js Lambda runtime defaults to treating .js as CommonJS, causing `SyntaxError: Cannot use import statement outside a module on every invocation` — hence all test events timing out in the raw layer. Changed the esbuild output extension from .js to .mjs; Lambda automatically treats .mjs as ESM and handler references (filename.handler) require no changes.