### PR TITLE
DPT-2768: Fix failing Lambdas (lambda script)

### DIFF
--- a/scripts/build-lambdas.sh
+++ b/scripts/build-lambdas.sh
@@ -11,6 +11,6 @@ for dir in "$SRC"/*; do
   srcPath="${dir}/handler.ts"
   lambdaName="${dir##*/}"
   echo "Building handlers/$lambdaName"
-  esbuild "$srcPath" --bundle --minify --sourcemap --platform=node --target=node24 --format=esm --outfile="$DIST/$lambdaName.js" --log-level=warning \
+  esbuild "$srcPath" --bundle --minify --sourcemap --platform=node --target=node24 --format=esm --outfile="$DIST/$lambdaName.mjs" --log-level=warning \
     --external:better-sqlite3 --external:better-mysql2 --external:mysql* --external:oracledb --external:pg-query-stream --external:sqlite3 --external:tedious
 done


### PR DESCRIPTION
The CI/CD pipeline calls `npm run build` → build-lambdas.sh, which still hardcodes `--outfile="$DIST/$lambdaName.js"`. The change to esbuild.config.ts has no effect because the shell script is what actually runs in the pipeline.