### PR TITLE
DPT-2768: Fix failing Lambdas; smithy dep

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -29,6 +29,7 @@ await Promise.all(
       platform: 'node',
       target: 'node24',
       format: 'esm',
+      mainFields: ['module', 'main'],
       outfile,
       logLevel: 'warning',
       // pg-native alternatives that are optional / non-node

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@aws-sdk/types": "^3.821.0",
         "@eslint/js": "^9.39.2",
         "@faker-js/faker": "^10.3.0",
-        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-retry": "^4.4.3",
         "@tsconfig/node24": "^24.0.0",
         "@types/aws-lambda": "^8.10.160",
         "@types/tar": "^6.1.13",
@@ -67,7 +67,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -3209,20 +3208,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3649,9 +3641,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3810,13 +3802,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.3.tgz",
+      "integrity": "sha512-8RJXeU5lEhdNfXm4XAuHlf6VtNzd279Z2FJZSR7VaELYCR46ffgjJBSjc+3UAy7V1YqBOLV0G9gWhLB/nA44nA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.24.3",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/types": "^3.821.0",
     "@eslint/js": "^9.39.2",
     "@faker-js/faker": "^10.3.0",
-    "@smithy/util-retry": "^4.0.6",
+    "@smithy/util-retry": "^4.4.3",
     "@tsconfig/node24": "^24.0.0",
     "@types/aws-lambda": "^8.10.160",
     "@types/tar": "^6.1.13",

--- a/scripts/build-lambdas.sh
+++ b/scripts/build-lambdas.sh
@@ -11,6 +11,6 @@ for dir in "$SRC"/*; do
   srcPath="${dir}/handler.ts"
   lambdaName="${dir##*/}"
   echo "Building handlers/$lambdaName"
-  esbuild "$srcPath" --bundle --minify --sourcemap --platform=node --target=node24 --format=esm --outfile="$DIST/$lambdaName.mjs" --log-level=warning \
+  esbuild "$srcPath" --bundle --minify --sourcemap --platform=node --target=node24 --format=esm --main-fields=module,main --outfile="$DIST/$lambdaName.mjs" --log-level=warning \
     --external:better-sqlite3 --external:better-mysql2 --external:mysql* --external:oracledb --external:pg-query-stream --external:sqlite3 --external:tedious
 done


### PR DESCRIPTION
Root cause: platform: 'node' sets esbuild's default field resolution order to ['main', 'module'] — CJS first. The @smithy CJS builds use require("buffer") which esbuild cannot convert when the output format is ESM.

Fix: mainFields: 'module', 'main' (CLI: --main-fields:module,main) reverses the priority so esbuild picks up @smithy's ESM distributions (dist-es/) instead, eliminating the dynamic require entirely.