### PR TITLE
DPT-2944 Add Delete retention policy attributes to persistant resources

### DIFF
--- a/iac/main/resources/athena.yml
+++ b/iac/main/resources/athena.yml
@@ -1,5 +1,7 @@
 AthenaWorkgroupBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-athena-workgroup
@@ -53,6 +55,8 @@ AthenaWorkgroupBucketPolicy:
 
 AthenaWorkGroup:
   Type: AWS::Athena::WorkGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Name: !Sub ${Environment}-dap-txma-processing
     Description: DAP project

--- a/iac/main/resources/cdn.yaml
+++ b/iac/main/resources/cdn.yaml
@@ -1,5 +1,7 @@
 DAPAnalystsFilesBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     AccessControl: Private

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -3,6 +3,8 @@
 # it also exists in production preview to allow manual event injection
 EventConsumerQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsDevOrBuild
   Properties:
     QueueName: !Sub ${Environment}-placeholder-txma-event-queue
@@ -13,6 +15,8 @@ EventConsumerQueue:
 
 EventConsumerDlq:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsDevOrBuild
   Properties:
     QueueName: !Sub ${Environment}-placeholder-txma-event-dlq
@@ -74,6 +78,8 @@ EventConsumerEventSourceMapping:
 
 KinesisFirehose:
   Type: 'AWS::KinesisFirehose::DeliveryStream'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     DeliveryStreamName: !Sub ${Environment}-${DeliveryStreamName}
     DeliveryStreamType: DirectPut
@@ -150,6 +156,8 @@ EventConsumerQueueTestUrl:
 
 E2ETestProducerQueueKmsKey:
   Type: AWS::KMS::Key
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsStaging
   Properties:
     EnableKeyRotation: true
@@ -190,6 +198,8 @@ E2ETestProducerQueueKmsKeyAlias:
 
 E2ETestProducerDeadLetterQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsStaging
   Properties:
     QueueName: !Sub ${Environment}-dap-e2e-test-producer-dlq
@@ -197,6 +207,8 @@ E2ETestProducerDeadLetterQueue:
 
 E2ETestProducerQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsStaging
   Properties:
     QueueName: !Sub ${Environment}-dap-e2e-test-producer-queue

--- a/iac/main/resources/event.yml
+++ b/iac/main/resources/event.yml
@@ -113,6 +113,8 @@ KinesisFirehose:
 
 IAMRoleKinesisFirehose:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-kinesis-txma-firehose-role
     AssumeRolePolicyDocument:

--- a/iac/main/resources/global.yml
+++ b/iac/main/resources/global.yml
@@ -177,6 +177,8 @@ S3NotificationsLoggerLambda:
 
 S3NotificationsLoggerEventBridgeRule:
   Type: AWS::Events::Rule
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Description: Rule to send all s3:ObjectCreated:* and s3:ObjectRemoved:* events to the logger lambda
     EventPattern:
@@ -202,6 +204,8 @@ S3BucketNotificationLambdaPermission:
 
 GlueSecurityConfig:
   Type: AWS::Glue::SecurityConfiguration
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Name: !Sub ${Environment}-dap-glue-security-configuration
     EncryptionConfiguration:
@@ -366,6 +370,8 @@ KmsKeyAlias:
 
 VPCForDAP:
   Type: AWS::EC2::VPC
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CidrBlock: 10.0.0.0/16
     EnableDnsHostnames: true
@@ -378,6 +384,8 @@ VPCForDAP:
 
 FlowLogRole:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AssumeRolePolicyDocument:
       Version: '2012-10-17'
@@ -409,6 +417,8 @@ FlowLogs:
 
 SubnetForDAP1:
   Type: AWS::EC2::Subnet
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     VpcId: !Ref VPCForDAP
     AvailabilityZone: !Select
@@ -424,6 +434,8 @@ SubnetForDAP1:
 
 SubnetForDAP2:
   Type: AWS::EC2::Subnet
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     VpcId: !Ref VPCForDAP
     AvailabilityZone: !Select
@@ -439,6 +451,8 @@ SubnetForDAP2:
 
 SubnetForDAP3:
   Type: AWS::EC2::Subnet
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     VpcId: !Ref VPCForDAP
     AvailabilityZone: !Select
@@ -454,6 +468,8 @@ SubnetForDAP3:
 
 RouteTableForDAP:
   Type: AWS::EC2::RouteTable
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Tags:
       - Key: Environment
@@ -482,6 +498,8 @@ SubnetRouteTableAssocDAP3:
 
 LambdaSecurityGroup:
   Type: AWS::EC2::SecurityGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     GroupName: !Sub ${Environment}-dap-lambda-security-group
     GroupDescription: Security group for DAP lambdas
@@ -621,6 +639,8 @@ VPCEndpointStepFunctions:
 
 VpcEndpointSecurityGroup:
   Type: 'AWS::EC2::SecurityGroup'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     GroupDescription: 'Security Group for VPC Endpoints'
     VpcId: !Ref VPCForDAP
@@ -693,6 +713,8 @@ VPCEndpointRedshiftServerless:
 
 AWSSupportReadOnlyRole:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: 'AWS-Support-ReadOnly'
     AssumeRolePolicyDocument:
@@ -788,6 +810,8 @@ TrailBucketPolicy:
 
 CloudTrailForUnauthorizedAPIChanges:
   Type: 'AWS::CloudTrail::Trail'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     S3BucketName: !Ref TrailBucket
     IncludeGlobalServiceEvents: true
@@ -838,6 +862,8 @@ UnauthorizedApiCallAlarm:
 
 CloudTrailCloudWatchLogsRole:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AssumeRolePolicyDocument:
       Version: '2012-10-17'
@@ -870,6 +896,8 @@ IAMChangeLogGroup:
 
 CloudTrailForIAMChanges:
   Type: 'AWS::CloudTrail::Trail'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     S3BucketName: !Ref TrailBucket
     IncludeGlobalServiceEvents: true

--- a/iac/main/resources/global.yml
+++ b/iac/main/resources/global.yml
@@ -1,6 +1,8 @@
 GlobalLogBucket:
   # checkov:skip=CKV_AWS_18: This is the log bucket for all other buckets - no need for a log bucket of the log bucket
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub '${Environment}-dap-s3-logs'
@@ -53,6 +55,8 @@ GlobalLogBucketPolicy:
 
 GlobalNonEventBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub '${Environment}-dap-s3-non-event'
@@ -101,6 +105,8 @@ GlobalNonEventBucketPolicy:
 
 VPCFlowLogsBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub '${Environment}-dap-vpc-flow-logs'
@@ -311,6 +317,8 @@ TestSupportLambdaTestingContainerPermission:
 
 KmsKey:
   Type: AWS::KMS::Key
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     EnableKeyRotation: true
     KeyPolicy:
@@ -721,6 +729,8 @@ AWSSupportReadOnlyRole:
 
 TrailBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub '${Environment}-dap-cloud-trail'
@@ -793,6 +803,8 @@ CloudTrailForUnauthorizedAPIChanges:
 
 UnauthorizedApiCallLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: !Sub /aws/dap-cloud-trail-log-group
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -810,6 +822,8 @@ UnauthorizedApiCallMetricFilter:
 
 UnauthorizedApiCallAlarm:
   Type: 'AWS::CloudWatch::Alarm'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AlarmName: UnauthorizedAPICallAlarm
     MetricName: UnauthorizedAPICallCount
@@ -847,6 +861,8 @@ CloudTrailCloudWatchLogsRole:
 
 IAMChangeLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: !Sub /aws/dap-IAM-changes-log-group
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -877,6 +893,8 @@ IAMChangeMetricFilter:
 
 IAMChangeAlarm:
   Type: 'AWS::CloudWatch::Alarm'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AlarmName: IAMPolicyChangeAlarm
     MetricName: IAMPolicyChangeCount
@@ -891,6 +909,8 @@ IAMChangeAlarm:
 
 IAMChangeAlertSNSTopic:
   Type: 'AWS::SNS::Topic'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     DisplayName: 'IAM Policy Change Alert'
     TopicName: 'IAMPolicyChangeAlert'
@@ -906,6 +926,8 @@ IAMChangeAlertSNSTopicSubscription:
 
 UnauthorizedApiCallSNSTopic:
   Type: 'AWS::SNS::Topic'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     DisplayName: 'Unauthorized API Call Alert'
     TopicName: 'UnauthorizedApiCallAlert'

--- a/iac/main/resources/manual-reference-data-ingestion.yml
+++ b/iac/main/resources/manual-reference-data-ingestion.yml
@@ -153,6 +153,8 @@ ProcessReferenceDataStateMachine:
 
 ReferenceDataProcessingPipeRole:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AssumeRolePolicyDocument:
       Version: '2012-10-17'
@@ -210,6 +212,8 @@ ReferenceDataProcessingPipe:
 
 GlueRedshiftConnection:
   Type: AWS::Glue::Connection
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Ref AWS::AccountId
     ConnectionInput:
@@ -358,6 +362,8 @@ S3RawToStagingLambdaPermission:
 ManualReferenceDataUploadRole:
   Condition: IsManualReferenceDataEnvironment
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-dap-manual-reference-data-upload-role
     AssumeRolePolicyDocument:

--- a/iac/main/resources/manual-reference-data-ingestion.yml
+++ b/iac/main/resources/manual-reference-data-ingestion.yml
@@ -41,6 +41,8 @@ RedshiftGetMetadataLambda:
 
 GlueJobResultsBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-glue-job-process-results
@@ -94,6 +96,8 @@ GlueJobResultsBucketPolicy:
 
 ReferenceDataSQSQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     ContentBasedDeduplication: true
     FifoQueue: true
@@ -106,6 +110,8 @@ ReferenceDataSQSQueue:
 
 DeadLetterQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     FifoQueue: true
     QueueName: !Sub ${Environment}-reference-data-processing-dlq.fifo
@@ -113,12 +119,16 @@ DeadLetterQueue:
 
 LambdaDeadLetterQueue:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     QueueName: !Sub ${Environment}-reference-data-processing-lambda-dlq
     KmsMasterKeyId: !GetAtt KmsKey.Arn
 
 ProcessReferenceDataLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/stepfunction/dap-reference-data-redshift-ingestion
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -215,6 +225,8 @@ GlueRedshiftConnection:
 
 ReferenceDataRedshiftIngestionGlueJob:
   Type: AWS::Glue::Job
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Command:
       Name: 'glueetl'
@@ -369,6 +381,8 @@ ManualReferenceDataUploadRole:
 
 ProcessReferenceDapAlertLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/events/reference-data-ingestion-pipeline-alert
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -442,6 +456,8 @@ ReferenceDataTopicRoutingPolicy:
 
 SNSReferenceDataAlertTopic:
   Type: AWS::SNS::Topic
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     TopicName: !Sub ${Environment}-reference-data-ingestion-alerts-topic
     KmsMasterKeyId: !GetAtt KmsKey.Arn

--- a/iac/main/resources/raw.yml
+++ b/iac/main/resources/raw.yml
@@ -56,6 +56,8 @@ RawLayerBucketPolicy:
 
 RawGlueCrawlerRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-raw-glue-crawler-role
     AssumeRolePolicyDocument:

--- a/iac/main/resources/raw.yml
+++ b/iac/main/resources/raw.yml
@@ -1,5 +1,7 @@
 RawLayerBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-raw-layer
@@ -94,6 +96,8 @@ RawGlueCrawlerRole:
 
 RawGlueDatabase:
   Type: AWS::Glue::Database
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
     DatabaseInput:
@@ -101,6 +105,8 @@ RawGlueDatabase:
 
 SplunkRawLayerSingleTableCrawler:
   Type: AWS::Glue::Crawler
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Name: splunk_migrated_data_fixed_schema
     Role: !GetAtt RawGlueCrawlerRole.Arn
@@ -120,6 +126,8 @@ SplunkRawLayerSingleTableCrawler:
 
 SplunkMigrationGlueTable:
   Type: AWS::Glue::Table
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
     DatabaseName: !Ref RawGlueDatabase
@@ -154,6 +162,8 @@ SplunkPerformanceIndexSecret:
 
 TxmaRefactoredTable:
   Type: AWS::Glue::Table
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Ref AWS::AccountId
     DatabaseName: !Ref RawGlueDatabase

--- a/iac/main/resources/redshift.yml
+++ b/iac/main/resources/redshift.yml
@@ -82,6 +82,8 @@ QuickSightEnvironmentPolicy:
 
 RedshiftSecret:
   Type: 'AWS::SecretsManager::Secret'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Description: This is a Secrets Manager secret for a Redshift cluster
     GenerateSecretString:
@@ -170,6 +172,8 @@ RedshiftSecretRotationLambdaPermission:
 
 RedshiftServerlessNamespace:
   Type: 'AWS::RedshiftServerless::Namespace'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AdminUsername: !Sub '{{resolve:secretsmanager:${RedshiftSecret}::username}}'
     AdminUserPassword: !Sub '{{resolve:secretsmanager:${RedshiftSecret}::password}}'
@@ -191,6 +195,8 @@ RedshiftServerlessNamespace:
 
 RedshiftServerlessWorkgroup:
   Type: 'AWS::RedshiftServerless::Workgroup'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     BaseCapacity: 256
     EnhancedVpcRouting: false
@@ -329,6 +335,8 @@ RunFlywayCommandLambda:
 
 FlywayFilesBucket:
   Type: AWS::S3::Bucket
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-flyway-files
@@ -586,6 +594,8 @@ RedshiftErrorEventRule:
 # Dead Letter Queue for failed EventBridge rule invocations
 RedshiftErrorDLQ:
   Type: AWS::SQS::Queue
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     QueueName: !Sub ${Environment}-dap-redshift-error-dlq
     MessageRetentionPeriod: 1209600 # 14 days

--- a/iac/main/resources/redshift.yml
+++ b/iac/main/resources/redshift.yml
@@ -1,5 +1,7 @@
 IAMRoleRedshiftServerless:
   Type: 'AWS::IAM::Role'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-redshift-serverless-role
     AssumeRolePolicyDocument:
@@ -217,6 +219,8 @@ RedshiftServerlessWorkgroup:
 
 RedshiftAccessEC2SecurityGroup:
   Type: 'AWS::EC2::SecurityGroup'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     GroupDescription: 'Security Group for Redshift Access EC2'
     VpcId: !Ref VPCForDAP
@@ -253,6 +257,8 @@ VPCDefaultSecurityGroupAllIngress:
 
 RedshiftMigrationRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-dap-redshift-migrate-role
     AssumeRolePolicyDocument:
@@ -390,6 +396,8 @@ FlywayFilesBucketPolicy:
 FlywayFilesBucketUploadRole:
   Condition: IsBuild
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: dap-flyway-files-upload-role
     AssumeRolePolicyDocument:
@@ -425,6 +433,8 @@ FlywayFilesBucketUploadRole:
 # Role to allow the data-analytics-adm repository the access to Redshift and related resources it needs
 DataAnalyticsADMRedshiftRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsADMEnvironment
   Properties:
     RoleName: !Sub data-analytics-adm-redshift-role
@@ -494,6 +504,8 @@ RedshiftCreateSnapshotLambda:
 
 RedshiftCreateSnapshotScheduledRule:
   Type: AWS::Events::Rule
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Name: !Sub ${Environment}-dap-redshift-create-snapshot-rule
     Description: Schedule to create redshift snapshots using the redshift-create-snapshot lambda
@@ -577,6 +589,8 @@ RedshiftWorkgroupNameParameter:
 # EventBridge rule to forward Redshift errors to SNS in same stack
 RedshiftErrorEventRule:
   Type: AWS::Events::Rule
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Name: !Sub ${Environment}-dap-redshift-error-rule
     Description: 'Forward Redshift errors to SNS'

--- a/iac/main/resources/slack.yml
+++ b/iac/main/resources/slack.yml
@@ -37,6 +37,8 @@ DAPNotificationsTopicSubscribePolicy:
 
 DAPNotificationChatbotRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${AWS::StackName}-notifications-chatbot-role
     PermissionsBoundary: !If

--- a/iac/main/resources/slack.yml
+++ b/iac/main/resources/slack.yml
@@ -1,5 +1,7 @@
 DAPNotificationsTopic:
   Type: AWS::SNS::Topic
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     TopicName: !Sub ${AWS::StackName}-alerts-notification-topic
     KmsMasterKeyId: !GetAtt KmsKey.Arn

--- a/iac/main/resources/stage.yml
+++ b/iac/main/resources/stage.yml
@@ -1,5 +1,7 @@
 StageLayerBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-stage-layer
@@ -54,6 +56,8 @@ StageLayerBucketPolicy:
 
 StageGlueDatabase:
   Type: AWS::Glue::Database
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
     DatabaseInput:

--- a/iac/main/resources/state-machine.yml
+++ b/iac/main/resources/state-machine.yml
@@ -1,5 +1,7 @@
 ELTMetadataBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-elt-metadata
@@ -81,6 +83,8 @@ ELTMetadataBucketPolicy:
 
 StateMachineResultsBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-step-function-process-results
@@ -134,6 +138,8 @@ StateMachineResultsBucketPolicy:
 
 AthenaRawLayerProcessingLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: !Sub /aws/stepfunction/dap-process-raw-layer
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -345,6 +351,8 @@ GlueLogGroupParameter:
 
 DataQualityMetricsBucket:
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     AccessControl: Private
     BucketName: !Sub ${Environment}-dap-data-quality-metrics
@@ -386,6 +394,8 @@ DataQualityMetricsBucketPolicy:
 
 DataQualityGlueDatabase:
   Type: AWS::Glue::Database
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
     DatabaseInput:
@@ -393,6 +403,8 @@ DataQualityGlueDatabase:
 
 DataQualityMetricsGlueTable:
   Type: AWS::Glue::Table
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
     DatabaseName: !Ref DataQualityGlueDatabase
@@ -422,6 +434,8 @@ DataQualityMetricsGlueTable:
 
 DataQualityPythonGlueJob:
   Type: AWS::Glue::Job
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Command:
       Name: pythonshell
@@ -609,6 +623,8 @@ GlueScriptsExecutionRole:
 
 RedshiftProcessingLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/stepfunction/dap-redshift-processing
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -758,6 +774,8 @@ TxmaRawLayerConsolidatedSchemaProcessingStateMachine:
 
 RawStageTransformProcessPythonGlueJob:
   Type: AWS::Glue::Job
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Command:
       Name: pythonshell
@@ -854,12 +872,16 @@ TopicRoutingPolicy:
 
 SNSAlertTopic:
   Type: AWS::SNS::Topic
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     TopicName: !Sub ${Environment}-dap-elt-support-management-topic
     KmsMasterKeyId: !GetAtt KmsKey.Arn
 
 DataQualityStageLayerOptimisedPythonGlueJob:
   Type: AWS::Glue::Job
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Command:
       Name: pythonshell
@@ -884,6 +906,8 @@ DataQualityStageLayerOptimisedPythonGlueJob:
 
 RedshiftConsolidatedModelProcessingLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/stepfunction/dap-consolidated-stage-layer-to-redshift
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -891,6 +915,8 @@ RedshiftConsolidatedModelProcessingLogGroup:
 
 ADMConsolidatedModelProcessingLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/stepfunction/dap-consolidated-conformed-layer-to-adm
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -898,6 +924,8 @@ ADMConsolidatedModelProcessingLogGroup:
 
 ADMV3RefreshLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     LogGroupName: /aws/stepfunction/dap-consolidated-conformed-layer-to-adm-v3
     KmsKeyId: !GetAtt KmsKey.Arn
@@ -970,6 +998,8 @@ ADMConsolidatedModelProcessingStateMachine:
 
 SplunkMigratedRawStageTransformProcessPythonGlueJob:
   Type: AWS::Glue::Job
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Command:
       Name: pythonshell

--- a/iac/main/resources/state-machine.yml
+++ b/iac/main/resources/state-machine.yml
@@ -22,6 +22,8 @@ ELTMetadataBucket:
 ELTMetadataUploadRole:
   Condition: IsBuild
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: dap-elt-metadata-upload-role
     AssumeRolePolicyDocument:
@@ -147,6 +149,8 @@ AthenaRawLayerProcessingLogGroup:
 
 StepFunctionRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-dap-statemachine-processing-role
     AssumeRolePolicyDocument:
@@ -461,6 +465,8 @@ DataQualityPythonGlueJob:
 
 GlueScriptsExecutionRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-dap-glue-scripts-execution-role
     AssumeRolePolicyDocument:
@@ -650,6 +656,8 @@ RedshiftProcessingStateMachine:
 
 StepFunctionRedshiftProcessRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   # AWS issue identified enabling CW logs for Step Function as detailed in the following link
   # https://repost.aws/questions/QURc2glxBETSe3Q6Y0UwcpQg/bug-with-loggingconfiguration
   # checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints
@@ -1041,6 +1049,8 @@ SplunkMigratedRawStageTransformProcessPythonGlueJob:
 
 HypercareAdjustedScheduleEventBridgeRule:
   Type: AWS::Events::Rule
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     Description: Rule to be enabled when rps require hypercare during onboarding
     ScheduleExpression: 'cron(30 9,13 * * ? *)'
@@ -1053,6 +1063,8 @@ HypercareAdjustedScheduleEventBridgeRule:
 
 HypercareAdjustedScheduleEventBridgeStateMachineInvokeRole:
   Type: AWS::IAM::Role
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     RoleName: !Sub ${Environment}-dap-hypercare-eventbridge-role
     AssumeRolePolicyDocument:

--- a/iac/main/resources/sustainability.yml
+++ b/iac/main/resources/sustainability.yml
@@ -11,6 +11,8 @@ SustainabilityAccountIds:
 
 SustainabilityDatabase:
   Type: AWS::Glue::Database
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsADMEnvironment
   Properties:
     CatalogId: !Sub ${AWS::AccountId}
@@ -19,6 +21,8 @@ SustainabilityDatabase:
 
 CurTable:
   Type: AWS::Glue::Table
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsADMEnvironment
   Properties:
     CatalogId: !Ref AWS::AccountId

--- a/iac/quicksight-access/resources/alerting.yml
+++ b/iac/quicksight-access/resources/alerting.yml
@@ -1,5 +1,7 @@
 DAPAlertsSNSTopic:
   Type: AWS::SNS::Topic
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsProduction
   Properties:
     DisplayName: Slack di_dap_alerts channel topic
@@ -39,6 +41,8 @@ DAPAlertsChatbotConfiguration:
 
 QuicksightSPICEUsageAlarm:
   Type: AWS::CloudWatch::Alarm
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsProduction
   Properties:
     ActionsEnabled: true

--- a/iac/quicksight-access/resources/quicksight-access.yml
+++ b/iac/quicksight-access/resources/quicksight-access.yml
@@ -1,6 +1,8 @@
 QuickSightLogBucket:
   # checkov:skip=CKV_AWS_18: This is the log bucket to log quicksight access
   Type: 'AWS::S3::Bucket'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     AccessControl: Private
@@ -79,6 +81,8 @@ QuicksightAccessLambdaFunction:
 
 QuicksightApiAccessLogGroup:
   Type: AWS::Logs::LogGroup
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Properties:
     KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
     LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-endpoint-access-logs
@@ -135,6 +139,8 @@ QuicksightAccessApiGatewayLambdaPermission2:
 
 QuicksightAccessUserPool:
   Type: AWS::Cognito::UserPool
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     AccountRecoverySetting:
@@ -184,6 +190,8 @@ QuicksightAccessUserPool:
 
 QuicksightAccessUserPoolClient:
   Type: AWS::Cognito::UserPoolClient
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     AllowedOAuthFlows:
@@ -214,6 +222,8 @@ QuicksightAccessUserPoolClient:
 
 QuicksightAccessUserPoolDomain:
   Type: AWS::Cognito::UserPoolDomain
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     Domain: !Sub ${Environment}-dap-quicksight-access
@@ -376,6 +386,8 @@ webAcl:
 
 cloudwatchLogsGroup:
   Type: 'AWS::Logs::LogGroup'
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     LogGroupName: !Sub 'aws-waf-logs-${Environment}-dap-cloudWatchLog'
@@ -426,6 +438,8 @@ WafAclSSM:
 
 WAFLoggingKmsKey:
   Type: AWS::KMS::Key
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     EnableKeyRotation: true
@@ -509,6 +523,8 @@ DataAnalyticsQuicksightSyncRole:
 
 QuicksightAccessKmsKey:
   Type: AWS::KMS::Key
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsProduction
   Properties:
     EnableKeyRotation: true
@@ -530,6 +546,8 @@ QuicksightAccessKmsKeyAlias:
 
 GoogleCredentialsSecret:
   Type: AWS::SecretsManager::Secret
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsProduction
   Properties:
     Description: Credentials JSON for a service account that can access the Google Sheets API

--- a/iac/quicksight-access/resources/quicksight-import-export.yml
+++ b/iac/quicksight-access/resources/quicksight-import-export.yml
@@ -1,5 +1,7 @@
 QuicksightExportBucket:
   Type: AWS::S3::Bucket
+  DeletionPolicy: Retain
+  UpdateReplacePolicy: Retain
   Condition: IsQuicksightEnvironment
   Properties:
     AccessControl: Private


### PR DESCRIPTION
Ticket: https://govukverify.atlassian.net/browse/DPT-2944

# Description

In order to make the reload of stacks easier I have added Deletion and retention policy tags to the CloudFormation templates for resources that hold data or state.

The stack has successfully deployed to the dev account.

# Testing

For now we just want to check that the tags are saved on the resources correctly which we can see in the console.
There are more tasks to complete before we can fully test the deletion and recreation of the stack.