### PR TITLE
DPT-3064: add mariadb to ignore list on build-lambdas.sh script

### DIFF
--- a/scripts/build-lambdas.sh
+++ b/scripts/build-lambdas.sh
@@ -12,5 +12,5 @@ for dir in "$SRC"/*; do
   lambdaName="${dir##*/}"
   echo "Building handlers/$lambdaName"
   esbuild "$srcPath" --bundle --minify --sourcemap --platform=node --target=node24 --format=esm --main-fields=module,main --outfile="$DIST/$lambdaName.mjs" --log-level=warning \
-    --external:better-sqlite3 --external:better-mysql2 --external:mysql* --external:oracledb --external:pg-query-stream --external:sqlite3 --external:tedious
+    --external:better-sqlite3 --external:better-mysql2 --external:mariadb --external:mysql* --external:oracledb --external:pg-query-stream --external:sqlite3 --external:tedious
 done


### PR DESCRIPTION
Ticket: https://govukverify.atlassian.net/browse/DPT-3064

Bug fix to unblock the build pipeline
After a Dependency upgrade, the knex library (version ^3.3.0) introduced support for MariaDB (which we don't use), so have applied an ignore flag with all the other DBs