### PR TITLE
DPT-3101: Fix prod quicksight role name

### DIFF
--- a/iac/quicksight-access/resources/pipeline.yml
+++ b/iac/quicksight-access/resources/pipeline.yml
@@ -50,7 +50,7 @@ WAFCognitoPolicy:
           - Ref: 'AWS::NoValue'
       - Fn::If:
           - IsProduction
-          - PL-dap-prod-deploy-qsa-DeployRole-0639afdddfd2
+          - PL-dap-prod-qs-access-DeployRole-0639afdddfd2
           - Ref: 'AWS::NoValue'
       - Fn::If:
           - IsBuild
@@ -140,7 +140,7 @@ QuickSightDeployRoleExtraIAMActions:
           - Ref: 'AWS::NoValue'
       - Fn::If:
           - IsProduction
-          - PL-dap-prod-deploy-qsa-DeployRole-0639afdddfd2
+          - PL-dap-prod-qs-access-DeployRole-0639afdddfd2
           - Ref: 'AWS::NoValue'
       - Fn::If:
           - IsBuild


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/DPT-3101

**Context**

Terragrunt changes caused misalignment with the quicksight role name, causing the build to fail.

**Fix**

1. Manually add temp role permissions to unblock the build
2. Merge the pipeline fix and watch it go through the environments
3. Remove the temp role fix
4. Check everything works as needed

